### PR TITLE
Squeeze Binary

### DIFF
--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,10 +1,27 @@
 FROM golang:latest as build-stage
-WORKDIR /build
+
+RUN apt-get update && apt-get -y install upx
+
+WORKDIR /src
+ENV GO111MODULE=on CGO_ENABLED=0
+
 COPY . .
+
 ARG SOURCE
-RUN GOOS="linux" go build -ldflags='-s -w' -o /bin/action actions/$SOURCE/main.go
+RUN go build \
+  -a \
+  -trimpath \
+  -ldflags "-s -w -extldflags '-static'" \
+  -installsuffix cgo \
+  -tags netgo \
+  -o /bin/action \
+  actions/$SOURCE/main.go
+
+RUN strip /bin/action
+
+RUN upx -q -9 /bin/action
 
 FROM scratch
-COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build-stage /bin/action /bin/
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build-stage /bin/action /bin/action
 ENTRYPOINT ["/bin/action"]


### PR DESCRIPTION
This change continues the Dockerfile updates so that the build now squeezes the binary before adding it to scratch.
