### PR TITLE
Repetition Tracking

### DIFF
--- a/.github/workflows/minimal-labels.yml
+++ b/.github/workflows/minimal-labels.yml
@@ -2,7 +2,6 @@ name: Minimal Labels
 "on":
     pull_request:
         types:
-            - opened
             - synchronize
             - reopened
             - labeled

--- a/octo/labels.go
+++ b/octo/labels.go
@@ -118,7 +118,6 @@ func ContributeLabels() ([]Contribution, error) {
 		On: map[event.Type]event.Event{
 			event.PullRequestType: event.PullRequest{
 				Types: []event.PullRequestActivityType{
-					event.PullRequestOpened,
 					event.PullRequestSynchronize,
 					event.PullRequestReopened,
 					event.PullRequestLabeled,


### PR DESCRIPTION
Previously when the minimal labels was created it ran on the obvious PR event types.  It turns out that running it on open was problematic because there was a race between the open event and the labeling events and often resulted in a PR being improperly marked as failing.  This change updates the created pipelines to not fire on open, but maintains all the rest of the PR event type triggers.