### PR TITLE
Remove GCS Filter Prefix

### DIFF
--- a/actions/gcs-dependency/main.go
+++ b/actions/gcs-dependency/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 
 	"cloud.google.com/go/storage"
@@ -49,7 +48,7 @@ func main() {
 	}
 
 	bucket := client.Bucket(b)
-	objects := bucket.Objects(context.Background(), &storage.Query{Prefix: filepath.Dir(g)})
+	objects := bucket.Objects(context.Background(), nil)
 
 	cp, err := regexp.Compile(g)
 	if err != nil {


### PR DESCRIPTION
Previously when a GCS bucket was listed, a prefix that was the equivalent of the parent directory of the interesting keys was added.  Unfortunately, if that parent directory had version numbers in it, it would break the listing. This change removes that prefix so that all viable candidates are listed.
