### PR TITLE
Crane in Create Builder

### DIFF
--- a/octo/create_builder.go
+++ b/octo/create_builder.go
@@ -44,6 +44,14 @@ func ContributeCreateBuilder(descriptor Descriptor) (*Contribution, error) {
 						Uses: "actions/checkout@v2",
 					},
 					{
+						Uses: "actions/setup-go@v2",
+						With: map[string]interface{}{"go-version": GoVersion},
+					},
+					{
+						Name: "Install crane",
+						Run:  statikString("/install-crane.sh"),
+					},
+					{
 						Name: "Install pack",
 						Run:  statikString("/install-pack.sh"),
 						Env:  map[string]string{"PACK_VERSION": PackVersion},


### PR DESCRIPTION
Previously, the Create Builder job ran generally properly, however the final step, updating a release with the digest of the builder in a registry did not work because crane had not been installed before retrieving the digest.  And unfortunately because of bash's suppression in subshells it took a first real release to detect the problem.

This change ensures that the create-builder job installs crane before it needs to be used.
