### PR TITLE
Remove Java 14

### DIFF
--- a/descriptors/adopt-openjdk.yml
+++ b/descriptors/adopt-openjdk.yml
@@ -45,22 +45,6 @@ dependencies:
     implementation: hotspot
     type:           jre
     version:        "[11,12)"
-- name:            JDK 14
-  id:              jdk
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/adopt-openjdk-dependency:main
-  with:
-    implementation: hotspot
-    type:           jdk
-    version:        "[14,15)"
-- name:            JRE 14
-  id:              jre
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/adopt-openjdk-dependency:main
-  with:
-    implementation: hotspot
-    type:           jre
-    version:        "[14,15)"
 - name:            JDK 15
   id:              jdk
   version_pattern: "15\\.[\\d]+\\.[\\d]+"

--- a/descriptors/azul-zulu.yml
+++ b/descriptors/azul-zulu.yml
@@ -41,20 +41,6 @@ dependencies:
   with:
     type:    headfull
     version: "11"
-- name:            JDK 14
-  id:              jdk
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
-  with:
-    type:    jdk
-    version: "14"
-- name:            JRE 14
-  id:              jre
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/azul-zulu-dependency:main
-  with:
-    type:    headfull
-    version: "14"
 - name:            JDK 15
   id:              jdk
   version_pattern: "15\\.[\\d]+\\.[\\d]+"

--- a/descriptors/bellsoft-liberica.yml
+++ b/descriptors/bellsoft-liberica.yml
@@ -41,20 +41,6 @@ dependencies:
   with:
     type:    jre
     version: "11"
-- name:            JDK 14
-  id:              jdk
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/bellsoft-liberica-dependency:main
-  with:
-    type:    jdk
-    version: "14"
-- name:            JRE 14
-  id:              jre
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/bellsoft-liberica-dependency:main
-  with:
-    type:    jre
-    version: "14"
 - name:            JDK 15
   id:              jdk
   version_pattern: "15\\.[\\d]+\\.[\\d]+"

--- a/descriptors/eclipse-openj9.yml
+++ b/descriptors/eclipse-openj9.yml
@@ -45,22 +45,6 @@ dependencies:
     implementation: openj9
     type:           jre
     version:        "[11,12)"
-- name:            JDK 14
-  id:              jdk
-  version_pattern: "14(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/adopt-openjdk-dependency:main
-  with:
-    implementation: openj9
-    type:           jdk
-    version:        "[14,15)"
-- name:            JRE 14
-  id:              jre
-  version_pattern: "14(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/adopt-openjdk-dependency:main
-  with:
-    implementation: openj9
-    type:           jre
-    version:        "[14,15)"
 - name:            JDK 15
   id:              jdk
   version_pattern: "15(?:\\.[\\d]+(?:\\.[\\d]+)?)?"

--- a/descriptors/sap-machine.yml
+++ b/descriptors/sap-machine.yml
@@ -33,26 +33,6 @@ dependencies:
     repository: SapMachine
     tag_filter: sapmachine-(11.*)
     token:      ${{ secrets.GITHUB_TOKEN }}
-- name:            JDK 14
-  id:              jdk
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
-  with:
-    glob:       sapmachine-jdk-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(14.*)
-    token:      ${{ secrets.GITHUB_TOKEN }}
-- name:            JRE 14
-  id:              jre
-  version_pattern: "14\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
-  with:
-    glob:       sapmachine-jre-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(14.*)
-    token:      ${{ secrets.GITHUB_TOKEN }}
 - name:            JDK 15
   id:              jdk
   version_pattern: "15\\.[\\d]+\\.[\\d]+"


### PR DESCRIPTION
With the release of Java 15.0.1, Java 14 is officially EOL. This change removes it from the buildpacks.
