### PR TITLE
Corretto Version Number

### DIFF
--- a/actions/amazon-corretto-dependency/main.go
+++ b/actions/amazon-corretto-dependency/main.go
@@ -75,7 +75,7 @@ func main() {
 							var s string
 
 							if v[1] == "8" {
-								s = fmt.Sprintf("%s.0.%s+%s", v[1], v[2], v[3])
+								s = fmt.Sprintf("%s.0.%s-%s", v[1], v[2], v[3])
 								if v[4] != "" {
 									s = fmt.Sprintf("%s-%s", s, v[4])
 								}


### PR DESCRIPTION
Previously, the version numbers used for comparison by the Amazon Corretto Dependency action took the "extended" portion of the version number and place it in semver metadata.  Metadata isn't used in ordered comparison by semver and therefore this information, which did have semantic meaning, was being ignored.

This change moves that same information to the pre-release portion of semver where it will be used for comparison.
