### PR TITLE
AdoptOpenJDK Version Number

### DIFF
--- a/actions/adopt-openjdk-dependency/main.go
+++ b/actions/adopt-openjdk-dependency/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/paketo-buildpacks/pipeline-builder/actions"
 )
@@ -71,7 +72,11 @@ func main() {
 
 	versions := make(actions.Versions)
 	for _, r := range raw {
-		versions[r.VersionData.Semver] = r.Binaries[0].Package.Link
+		versions[strings.ReplaceAll(r.VersionData.Semver, "+", "-")] = r.Binaries[0].Package.Link
+	}
+
+	for k, _ := range versions {
+		fmt.Println(k)
 	}
 
 	if o, err := versions.GetLatest(inputs); err != nil {


### PR DESCRIPTION
Previously, the version numbers used for comparison by the AdoptOpenJDK Dependency action took the semver version number, as declared by the API including a portion in semver metadata.  Metadata isn't used in ordered comparison by semver and therefore this information, which did have semantic meaning, was being ignored.

This change moves that same information to the pre-release portion of semver where it will be used for comparison.
