### PR TITLE
Reduced Schedule

### DIFF
--- a/octo/builder_dependencies.go
+++ b/octo/builder_dependencies.go
@@ -75,7 +75,7 @@ func contributeBuildImage(descriptor Descriptor, image string, classifier string
 	w := actions.Workflow{
 		Name: "Update Build Image",
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "15"}},
+			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "5", DayOfWeek: "1-5"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{
@@ -143,7 +143,7 @@ func contributeLifecycle() (Contribution, error) {
 	w := actions.Workflow{
 		Name: "Update Lifecycle",
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "15"}},
+			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "5", DayOfWeek: "1-5"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{

--- a/octo/buildpack_dependencies.go
+++ b/octo/buildpack_dependencies.go
@@ -32,7 +32,7 @@ func ContributeBuildpackDependencies(descriptor Descriptor) ([]Contribution, err
 		w := actions.Workflow{
 			Name: fmt.Sprintf("Update %s", d.Name),
 			On: map[event.Type]event.Event{
-				event.ScheduleType:         event.Schedule{{Minute: "30"}},
+				event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "5", DayOfWeek: "1-5"}},
 				event.WorkflowDispatchType: event.WorkflowDispatch{},
 			},
 			Jobs: map[string]actions.Job{

--- a/octo/offline_packages.go
+++ b/octo/offline_packages.go
@@ -43,7 +43,7 @@ func contributeOfflinePackage(descriptor Descriptor, offlinePackage OfflinePacka
 	w := actions.Workflow{
 		Name: fmt.Sprintf("Create Package %s", filepath.Base(offlinePackage.Target)),
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "45"}},
+			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "12-23", DayOfWeek: "1-5"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{

--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -65,7 +65,7 @@ func contributePackageDependency(descriptor Descriptor, name string) (Contributi
 	w := actions.Workflow{
 		Name: fmt.Sprintf("Update %s", filepath.Base(name)),
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "0"}},
+			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "12-23", DayOfWeek: "1-5"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.
