### PR TITLE
Crane Version

### DIFF
--- a/octo/builder_dependencies.go
+++ b/octo/builder_dependencies.go
@@ -96,7 +96,7 @@ func contributeBuildImage(descriptor Descriptor, image string, classifier string
 					{
 						Name: "Install crane",
 						Run:  statikString("/install-crane.sh"),
-						Env:  map[string]string{"CraneVersion": CraneVersion},
+						Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 					},
 					{
 						Name: "Install yj",

--- a/octo/create_builder.go
+++ b/octo/create_builder.go
@@ -47,7 +47,7 @@ func ContributeCreateBuilder(descriptor Descriptor) (*Contribution, error) {
 					{
 						Name: "Install crane",
 						Run:  statikString("/install-crane.sh"),
-						Env:  map[string]string{"CraneVersion": CraneVersion},
+						Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 					},
 					{
 						Name: "Install pack",

--- a/octo/create_package.go
+++ b/octo/create_package.go
@@ -60,7 +60,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 					{
 						Name: "Install crane",
 						Run:  statikString("/install-crane.sh"),
-						Env:  map[string]string{"CraneVersion": CraneVersion},
+						Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 					},
 					{
 						Name: "Install pack",

--- a/octo/draft_release.go
+++ b/octo/draft_release.go
@@ -123,7 +123,7 @@ func ContributeDraftRelease(descriptor Descriptor) ([]Contribution, error) {
 				actions.Step{
 					Name: "Install crane",
 					Run:  statikString("/install-crane.sh"),
-					Env:  map[string]string{"CraneVersion": CraneVersion},
+					Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 				},
 			)
 		}

--- a/octo/offline_packages.go
+++ b/octo/offline_packages.go
@@ -54,7 +54,7 @@ func contributeOfflinePackage(descriptor Descriptor, offlinePackage OfflinePacka
 					{
 						Name: "Install crane",
 						Run:  statikString("/install-crane.sh"),
-						Env:  map[string]string{"CraneVersion": CraneVersion},
+						Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 					},
 					{
 						Uses: "actions/checkout@v2",

--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -84,7 +84,7 @@ func contributePackageDependency(descriptor Descriptor, name string) (Contributi
 					{
 						Name: "Install crane",
 						Run:  statikString("/install-crane.sh"),
-						Env:  map[string]string{"CraneVersion": CraneVersion},
+						Env:  map[string]string{"CRANE_VERSION": CraneVersion},
 					},
 					{
 						Name: "Install yj",


### PR DESCRIPTION
Previously the wrong environment variable name was used when configuring the crane version.
