### PR TITLE
Build On Descriptor Change

### DIFF
--- a/.github/workflows/update-pipeline.yml
+++ b/.github/workflows/update-pipeline.yml
@@ -1,5 +1,10 @@
 name: Update Pipeline
 "on":
+    push:
+        branches:
+            - main
+        paths:
+            - .github/pipeline-descriptor.yml
     schedule:
         - cron: 0 5 * * 1-5
     workflow_dispatch: {}

--- a/octo/update_pipeline.go
+++ b/octo/update_pipeline.go
@@ -27,6 +27,10 @@ func ContributeUpdatePipeline(descriptor Descriptor) (Contribution, error) {
 	w := actions.Workflow{
 		Name: "Update Pipeline",
 		On: map[event.Type]event.Event{
+			event.PushType: event.Push{
+				Branches: []string{"main"},
+				Paths:    []string{filepath.Join(".github", "pipeline-descriptor.yml")},
+			},
 			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "5", DayOfWeek: "1-5"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},


### PR DESCRIPTION
This change updates the update-pipeline workflow to trigger any time the descriptor changes, in addition to the times previously did.
