### PR TITLE
Turns off dependabot upgrades of github actions

### DIFF
--- a/octo/dependabot.go
+++ b/octo/dependabot.go
@@ -26,14 +26,6 @@ import (
 func ContributeDependabot(descriptor Descriptor) (Contribution, error) {
 	d := dependabot.Dependabot{
 		Version: dependabot.Version,
-		Updates: []dependabot.Update{
-			{
-				PackageEcosystem: dependabot.GitHubActionsPackageEcosystem,
-				Directory:        "/",
-				Schedule:         dependabot.Schedule{Interval: dependabot.DailyInterval},
-				Labels:           []string{"semver:patch", "type:dependency-upgrade"},
-			},
-		},
 	}
 
 	file := filepath.Join(descriptor.Path, "go.mod")


### PR DESCRIPTION
## Summary
Because certain action versions are hardcoded in our pipeline definition, allowing dependabot to upgrade actions would cause the update-pipeline job and dependabot to fight with each other over the action version.


## Use Cases
For example, [this dependabot PR](https://github.com/paketo-buildpacks/gradle/pull/51) is attempting to change `actions/cache@v2` to `actions/cache@v2.1.4`. However, if we merge this PR, the pipeline updater will attempt to [change it back](https://github.com/paketo-buildpacks/pipeline-builder/blob/main/octo/create_package.go#L64).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
