### PR TITLE
Uses request-add-entry action instead of registry action

### DIFF
--- a/octo/create_package.go
+++ b/octo/create_package.go
@@ -131,7 +131,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 						},
 					},
 					{
-						Uses: "docker://ghcr.io/buildpacks/actions/registry:main",
+						Uses: "docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1",
 						If:   fmt.Sprintf("${{ %t }}", descriptor.Package.Register),
 						With: map[string]interface{}{
 							"token":   descriptor.Package.RegistryToken,


### PR DESCRIPTION
## Summary
Uses ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1 action in generated pipelines instead of ghcr.io/buildpacks/actions/registry:main

## Use Cases
`ghcr.io/buildpacks/actions/registry:main` action is not documented in the buildpacks/github-actions README and has not been updated in several months.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
