### PR TITLE
Guard against writing empty dependabot.yml files

### DIFF
--- a/octo/octo.go
+++ b/octo/octo.go
@@ -74,8 +74,8 @@ func Contribute(path string) error {
 
 	if c, err := ContributeDependabot(descriptor); err != nil {
 		return err
-	} else {
-		contributions = append(contributions, c)
+	} else if c != nil {
+		contributions = append(contributions, *c)
 	}
 
 	if c, err := ContributeBuildpackDependencies(descriptor); err != nil {


### PR DESCRIPTION
## Summary
Dependabot requires updates to be an array and it will fail if omitted or empty. The dependabot.yml file will need to be manually deleted from repos where it is current empty or no longer needed (now that we no longer subscribe to GHA updates) because the pipeline builder does not delete files.

## Use Cases
This affect repos that previously had GHA in their dependabot update config and now do not require dependabot at all (build package and builder repos).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
