### PR TITLE
Move setup-go to the top, so the proper version of Go is installed before Go is used for any reason

### DIFF
--- a/octo/test.go
+++ b/octo/test.go
@@ -121,6 +121,10 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 			Steps: []actions.Step{
 				{
+					Uses: "actions/setup-go@v2",
+					With: map[string]interface{}{"go-version": GoVersion},
+				},
+				{
 					Name: "Install create-package",
 					Run:  StatikString("/install-create-package.sh"),
 				},
@@ -133,10 +137,6 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 					Name: "Enable pack Experimental",
 					If:   fmt.Sprintf("${{ %t }}", descriptor.Package.Platform.OS == PlatformWindows),
 					Run:  StatikString("/enable-pack-experimental.sh"),
-				},
-				{
-					Uses: "actions/setup-go@v2",
-					With: map[string]interface{}{"go-version": GoVersion},
 				},
 				{
 					Uses: "actions/checkout@v2",


### PR DESCRIPTION
## Summary

Previously, setup-go was run later and so you would have the install tasks running with an older version of Go.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
