### PR TITLE
Removed the Docker Login step from Create Test Package job as it fail…

### DIFF
--- a/octo/test.go
+++ b/octo/test.go
@@ -178,7 +178,6 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			},
 		}
 
-		j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
 		j.Steps = append(NewHttpCredentialActions(descriptor.HttpCredentials), j.Steps...)
 
 		w.Jobs["create-package"] = j


### PR DESCRIPTION
…s for dependabot and is unnecessary for the test

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Dependabot-created PRs always fail the 'Create Package Tests' action, as the 'Docker Login' step is not provided with any credentials (expected). This step should not be run anyway but does due to a conditional logic bug. Opted to remove the 'Docker Login' step entirely from this action because it does not need to connect to Docker anyway.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
