### PR TITLE
Added 'Docker Login' Step back to support required cases

### DIFF
--- a/octo/contribution.go
+++ b/octo/contribution.go
@@ -90,7 +90,7 @@ func NewDockerCredentialActions(credentials []DockerCredentials) []actions.Step 
 	for _, c := range credentials {
 		s = append(s, actions.Step{
 			Name: fmt.Sprintf("Docker login %s", c.Registry),
-			If:   "${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}",
+			If:   "${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}",
 			Uses: "docker/login-action@v1",
 			With: map[string]interface{}{
 				"registry": c.Registry,

--- a/octo/test.go
+++ b/octo/test.go
@@ -178,6 +178,9 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			},
 		}
 
+		if !strings.Contains(descriptor.Package.Repository, "paketo-buildpacks") {
+			j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
+		}
 		j.Steps = append(NewHttpCredentialActions(descriptor.HttpCredentials), j.Steps...)
 
 		w.Jobs["create-package"] = j


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Removing the Docker Login step completely from 'Create Package Test' action caused failures for some composite buildpacks where it is required. This patch adds the step back for non Paketo buildpacks and also adds a check which will not run the Login step if the actor is Dependabot, since it will not have the required credentials to succeed(recommended by Github Support).

## Use Cases
The Docker Login step will continue to fail for Dependabot PRs in some composite buildpacks, re-running the action should supply the credentials and the check should then pass.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
