### PR TITLE
Switch from using the Azure to Community API for Azul

### DIFF
--- a/actions/azul-zulu-dependency/main.go
+++ b/actions/azul-zulu-dependency/main.go
@@ -38,7 +38,7 @@ func main() {
 		panic(fmt.Errorf("version must be specified"))
 	}
 
-	uri := fmt.Sprintf("https://api.azul.com/zulu/download/azure-only/v1.0/bundles/latest/"+
+	uri := fmt.Sprintf("https://api.azul.com/zulu/download/community/v1.0/bundles/latest/"+
 		"?arch=x86"+
 		"&ext=tar.gz"+
 		"&features=%s"+


### PR DESCRIPTION


<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The Microsoft & Azul partnership for Azure is ending shortly. As such, we are switching to use the community API like everyone else. In coordination with this, we'll be shipping future paketo-buildpacks/java-azure buildpacks with the Microsoft OpenJDK instead of Azul.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
