### PR TITLE
Added ibm-semeru-dependency action to support new location of Eclipse…

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -40,6 +40,8 @@ actions:
   target: ghcr.io/paketo-buildpacks/actions/graalvm-dependency
 - source: gradle-dependency
   target: ghcr.io/paketo-buildpacks/actions/gradle-dependency
+- source: ibm-semeru-dependency
+  target: ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency
 - source: jprofiler-dependency
   target: ghcr.io/paketo-buildpacks/actions/jprofiler-dependency
 - source: jrebel-dependency

--- a/actions/ibm-semeru-dependency/main.go
+++ b/actions/ibm-semeru-dependency/main.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	"golang.org/x/oauth2"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	o, ok := inputs["owner"]
+	if !ok {
+		panic(fmt.Errorf("owner must be specified"))
+	}
+
+	r, ok := inputs["repository"]
+	if !ok {
+		panic(fmt.Errorf("repository must be specified"))
+	}
+
+	var (
+		err error
+		g   *regexp.Regexp
+	)
+	if s, ok := inputs["glob"]; ok {
+		g, err = regexp.Compile(s)
+		if err != nil {
+			panic(fmt.Errorf("unable to compile %s as a regexp\n%w", s, err))
+		}
+	} else {
+		g = regexp.MustCompile(".+")
+	}
+
+	t := `v?([^v].*)`
+	if s, ok := inputs["tag_filter"]; ok {
+		t = s
+	}
+
+	var c *http.Client
+	if s, ok := inputs["token"]; ok {
+		c = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s}))
+	}
+	gh := github.NewClient(c)
+
+	versions := make(actions.Versions)
+
+	re, err := regexp.Compile(t)
+	if err != nil {
+		panic(fmt.Errorf("%s is not a valid regex", t))
+	}
+
+	opt := &github.ListOptions{PerPage: 100}
+	for {
+		rel, rsp, err := gh.Repositories.ListReleases(context.Background(), o, r, opt)
+		if err != nil {
+			panic(fmt.Errorf("unable to list existing releases for %s/%s\n%w", o, r, err))
+		}
+
+		for _, r := range rel {
+			if *r.Prerelease {
+				continue
+			}
+
+			if p := re.FindStringSubmatch(*r.TagName); p != nil {
+
+				for _, a := range r.Assets {
+					if g.MatchString(*a.Name) {
+						// get the matched asset's associated json file
+						versionJSON := *a.BrowserDownloadURL + ".json"
+						// Decode JSON so we can extract 'version.semver'
+						json := getReleaseJSON(versionJSON)
+						// Record semver against the asset's tar.gz URL
+						versions[strings.ReplaceAll(json.VersionData.Semver, "+", "-")] = *a.BrowserDownloadURL
+
+						break
+					}
+				}
+			}
+		}
+
+		if rsp.NextPage == 0 {
+			break
+		}
+		opt.Page = rsp.NextPage
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}
+
+func getReleaseJSON(jsonURI string) ReleaseJSON {
+	resp, err := http.Get(jsonURI)
+	if err != nil {
+		panic(fmt.Errorf("unable to get %s\n%w", jsonURI, err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		panic(fmt.Errorf("unable to download %s: %d", jsonURI, resp.StatusCode))
+	}
+
+	var raw ReleaseJSON
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		panic(fmt.Errorf("unable to decode payload\n%w", err))
+	}
+
+	return raw
+
+}
+
+type ReleaseJSON struct {
+	VersionData VersionData `json:"version"`
+}
+
+type VersionData struct {
+	Semver string
+}


### PR DESCRIPTION
… OpenJ9 binaries

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Adoptium no longer provides Eclipse OpenJ9 binaries, these are now owned by [IBM](https://developer.ibm.com/languages/java/semeru-runtimes/downloads). This PR adds a new action with the "ibm-semeru-dependency" which looks at [github.com/ibmruntimes/semeru*](https://github.com/ibmruntimes/semeru11-binaries/releases) for OpenJ9 binaries 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
