### PR TITLE
Add new actions

### DIFF
--- a/actions/cf-java-index-dependency/main.go
+++ b/actions/cf-java-index-dependency/main.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	repositoryRoot, ok := inputs["repository_root"]
+	if !ok {
+		panic(fmt.Errorf("repository_root must be specified"))
+	}
+
+	uri := fmt.Sprintf("%s/index.yml", repositoryRoot)
+	resp, err := http.Get(uri)
+	if err != nil {
+		panic(fmt.Errorf("unable to get %s\n%w", uri, err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		panic(fmt.Errorf("unable to download %s: %d", uri, resp.StatusCode))
+	}
+
+	raw := make(map[string]string)
+	if err := yaml.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		panic(fmt.Errorf("unable to decode payload\n%w", err))
+	}
+
+	versions := make(actions.Versions)
+	for k, v := range raw {
+		versions[k] = v
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}

--- a/actions/paketo-deps-dependency/main.go
+++ b/actions/paketo-deps-dependency/main.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	name, ok := inputs["name"]
+	if !ok {
+		panic(fmt.Errorf("name must be specified"))
+	}
+
+	uri := "https://api.deps.paketo.io/v1/dependency?name=%s"
+	resp, err := http.Get(fmt.Sprintf(uri, name))
+	if err != nil {
+		panic(fmt.Errorf("unable to get %s\n%w", uri, err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		panic(fmt.Errorf("unable to download %s: %d", uri, resp.StatusCode))
+	}
+
+	var raw []struct {
+		Uri     string `json:"uri"`
+		Version string `json:"version"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		panic(fmt.Errorf("unable to decode payload\n%w", err))
+	}
+
+	versions := make(actions.Versions)
+	for _, r := range raw {
+		versions[r.Version] = r.Uri
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}

--- a/actions/rustup-init-dependency/main.go
+++ b/actions/rustup-init-dependency/main.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/google/go-github/v32/github"
+	"golang.org/x/oauth2"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+const (
+	ORG  = "rust-lang"
+	REPO = "rustup"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	target, ok := inputs["target"]
+	if !ok {
+		panic(fmt.Errorf("target must be specified"))
+	}
+
+	var c *http.Client
+	if s, ok := inputs["token"]; ok {
+		c = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s}))
+	}
+	gh := github.NewClient(c)
+
+	versions := make(actions.Versions)
+
+	opt := &github.ListOptions{PerPage: 100}
+	for {
+		tags, rsp, err := gh.Repositories.ListTags(context.Background(), ORG, REPO, opt)
+		if err != nil {
+			panic(fmt.Errorf("unable to list existing tags for %s/%s\n%w", ORG, REPO, err))
+		}
+
+		for _, t := range tags {
+			normalVersion, err := actions.NormalizeVersion(*t.Name)
+			if err != nil {
+				panic(err)
+			}
+
+			versions[normalVersion] = fmt.Sprintf("https://static.rust-lang.org/rustup/archive/"+
+				"%s/%s/rustup-init", normalVersion, target)
+		}
+
+		if rsp.NextPage == 0 {
+			break
+		}
+		opt.Page = rsp.NextPage
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for new update actions.

## Use Cases
- Adds an action for reading CF Java Buildpack index.yml files
- Adds an action for reading deps from the Paketo deps server API
- Adds an action for reading Rustup versions from Github


## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
