### PR TITLE
Improve the ordering of GHA workflow fields

### DIFF
--- a/octo/actions/workflow.go
+++ b/octo/actions/workflow.go
@@ -30,12 +30,12 @@ type Workflow struct {
 
 type Job struct {
 	Name            string               `yaml:",omitempty"`
+	If              string               `yaml:",omitempty"`
 	Needs           []string             `yaml:",omitempty"`
 	RunsOn          []VirtualEnvironment `yaml:"runs-on,omitempty"`
 	Outputs         map[string]string    `yaml:",omitempty"`
 	Env             map[string]string    `yaml:",omitempty"`
 	Defaults        Defaults             `yaml:",omitempty"`
-	If              string               `yaml:",omitempty"`
 	Steps           []Step               `yaml:",omitempty"`
 	TimeoutMinutes  int                  `yaml:",omitempty"`
 	Strategy        Strategy             `yaml:",omitempty"`
@@ -50,9 +50,9 @@ type Run struct {
 }
 
 type Step struct {
-	Id               string            `yaml:",omitempty"`
-	If               string            `yaml:",omitempty"`
 	Name             string            `yaml:",omitempty"`
+	If               string            `yaml:",omitempty"`
+	Id               string            `yaml:",omitempty"`
 	Uses             string            `yaml:",omitempty"`
 	Run              string            `yaml:",omitempty"`
 	WorkingDirectory string            `yaml:"working-directory,omitempty"`


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When building the YAML file (GHA workflow) using the workflow structs defined in `./octo/actions/**`, IF conditional is placed above the step name. This behaviour is not optimal as it's much easier to read workflows where conditionals are used **below** the step name. This can be easily fixed by switching the fields in the defined structs. 

Examples of workflows used in acknowledged repositories where conditional is placed below the name, proving the common practice of putting the conditional below the name:
- https://github.com/tldr-pages/tldr/blob/main/.github/workflows/ci.yml#L39
- https://github.com/appsmithorg/appsmith/blob/release/.github/workflows/server.yml#L100

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
