### PR TITLE
Set a different buildpack id, if necessary

### DIFF
--- a/octo/builder_dependencies.go
+++ b/octo/builder_dependencies.go
@@ -48,7 +48,7 @@ func ContributeBuilderDependencies(descriptor Descriptor) ([]Contribution, error
 	re := regexp.MustCompile(`^(?:.+://)?(.+):[^:]+$`)
 	for _, b := range r.Buildpacks {
 		if g := re.FindStringSubmatch(b.URI); g != nil {
-			if c, err := contributePackageDependency(descriptor, g[1]); err != nil {
+			if c, err := contributePackageDependency(descriptor, g[1], g[1]); err != nil {
 				return nil, err
 			} else {
 				contributions = append(contributions, c)

--- a/octo/package/package.go
+++ b/octo/package/package.go
@@ -16,10 +16,16 @@
 
 package _package
 
+import "github.com/buildpacks/libcnb"
+
 type Package struct {
 	Dependencies []Dependency
 }
 
 type Dependency struct {
 	URI string
+}
+
+type BuildpackOrderGroups struct {
+	Orders []libcnb.BuildpackOrder `toml:"order"`
 }


### PR DESCRIPTION
## Summary
Most buildpacks have a buildpack id that can be extracted from the package id. For example `gcr.io/paketo-buildpacks/bellsoft-liberica` has a buildpack id of `paketo-buildpacks/bellsoft-liberica`. This doesn't have to be the case though.

It is possible for the package id to be something like `gcr.io/my-buildpacks/bellsoft-liberica` but the buildpack id is still `paketo-buildpacks/bellsoft-liberica`, like if you are making your own custom packages of a buildpack. In this case, to find the correct buildpack id the code will take the laste part of the package id, i.e. `bellsoft-liberica` and the indicated version, look through buildpack.toml and see if there is a match where some buildpack id ends with last part of the package id and has a matching version. If it locates a fuzzy match, the well use that id. If not, it fails.


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
