### PR TITLE
Only publish actions to main tag

### DIFF
--- a/octo/actions.go
+++ b/octo/actions.go
@@ -56,18 +56,13 @@ func ContributeActions(descriptor Descriptor) ([]Contribution, error) {
 							Uses: "actions/checkout@v2",
 						},
 						{
-							Id:   "version",
-							Name: "Compute Version",
-							Run:  StatikString("/compute-version.sh"),
-						},
-						{
 							Name: "Create Action",
 							Run:  StatikString("/create-action.sh"),
 							Env: map[string]string{
 								"PUSH":    "${{ github.event_name != 'pull_request' }}",
 								"SOURCE":  a.Source,
 								"TARGET":  a.Target,
-								"VERSION": "${{ steps.version.outputs.version }}",
+								"VERSION": "main",
 							},
 						},
 					},


### PR DESCRIPTION
## Summary
We have been publishing actions to a main tag and tags that match the version of pipeline-builder. After a recent review, it has been made clear that we are only ever consuming the 'main' tag. You can see this is the pull stats for the images in Github. The tagged releases have 0 pulls. Main has a few thousand. In addition, the pipeline-descriptor.yml files all have `:main` on the actions.

As such, it doesn't make sense to keep publishing under the version tags. This means that when a release is cut and a new version tag is created, it goes unused. At the same time, the main tag isn't updated and so the two can diverge. The only downside, is that you cannot rollback to a previous version by simply changing the tag name. This is not something being done, as you can see by the pull stats, and it's probably less work to just commit a fix to pipeline builder and republish the action under the 'main' tag.

This PR removes the logic to pick the version & hard codes the version to 'main'. This should ensure that all pushes go to the 'main' label and are thus immediately able to be consumed.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
