### PR TITLE
Add javafx with value false to azul zulu uri

### DIFF
--- a/actions/azul-zulu-dependency/main.go
+++ b/actions/azul-zulu-dependency/main.go
@@ -44,7 +44,8 @@ func main() {
 		"&features=%s"+
 		"&hw_bitness=64"+
 		"&jdk_version=%s"+
-		"&os=linux",
+		"&os=linux"+
+		"&javafx=false",
 		t, v)
 
 	resp, err := http.Get(uri)


### PR DESCRIPTION
[PR](https://github.com/paketo-buildpacks/azul-zulu/pull/134) was
automatically created including jdk + javafx. In order to avoid
those PRs, the uri is excluding those.
