### PR TITLE
Bumps versions for richgo, pack and crane used by pipeline tools

### DIFF
--- a/octo/octo.go
+++ b/octo/octo.go
@@ -29,10 +29,10 @@ import (
 //go:generate statik -src . -include *.sh
 
 const (
-	CraneVersion  = "0.5.1"
+	CraneVersion  = "0.6.0"
 	GoVersion     = "1.16"
-	PackVersion   = "0.18.1"
-	RichGoVersion = "0.3.6"
+	PackVersion   = "0.21.1"
+	RichGoVersion = "0.3.9"
 	YJVersion     = "5.0.0"
 )
 


### PR DESCRIPTION
## Summary
Pipline tools are falling behind a bit, this bumps them to the most recent versions at the time of this commit.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
