### PR TITLE
Change the way Java stackdriver version is being represented

### DIFF
--- a/actions/google-stackdriver-profiler-dependency/main.go
+++ b/actions/google-stackdriver-profiler-dependency/main.go
@@ -51,7 +51,7 @@ func main() {
 		}
 
 		if p := cp.FindStringSubmatch(o.Name); p != nil {
-			versions[fmt.Sprintf("%s.%s", p[1], p[2])] = fmt.Sprintf("https://storage.googleapis.com/%s/%s", o.Bucket, o.Name)
+			versions[fmt.Sprintf("%s.%s.%s%s", p[1][0:4], p[1][4:6], p[1][6:8], p[2])] = fmt.Sprintf("https://storage.googleapis.com/%s/%s", o.Bucket, o.Name)
 		}
 	}
 


### PR DESCRIPTION
## Summary
The Google Stackdriver Java agent is using a date-based version. Previously, this action would take the date part and stuff that into the major version field, followed by the RC number as the minor version. This resulted in the buildpack bumping a major version for every release unless it's manually corrected.

This PR changes the transformation of the date to a version such that the major version won't change nearly as often. It takes the year from the date and sets that to the major version, the month to the minor version and the patch version becomes the combination of the date and the RC number. Ex: 2021.11.100.

It's not perfect, but we need a version in that format and this will ensure that we're not bumping major versions every time a new release drops.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
