### PR TITLE
Fixes typo that caused non-stable releases to be selected

### DIFF
--- a/actions/clojure-tools-dependency/main.go
+++ b/actions/clojure-tools-dependency/main.go
@@ -99,13 +99,13 @@ func main() {
 			panic(err)
 		}
 
-		versions := make(actions.Versions)
+		versions = make(actions.Versions)
 		versions[normalVersion] = fmt.Sprintf("https://download.clojure.org/install/linux-install-%s.sh", origVersion)
-	}
 
-	if o, err := versions.GetLatest(inputs); err != nil {
-		panic(err)
-	} else {
-		o.Write(os.Stdout)
+		if o, err := versions.GetLatest(inputs); err != nil {
+			panic(err)
+		} else {
+			o.Write(os.Stdout)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- There was a typo that caused the filtered list of versions to only be present within the if {..} block. When the call to GetLatest and Write happend, it was picking from the original list, not the list within the if {..} block.
- This PR fixes the typo and moves the GetLatest/Write calls within the same if {..} block so that it's hopefully more clear what is happening.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
