### PR TITLE
Fixes bug where name and website were being stripped from the metadata when updating the buildpack metadata labels

### DIFF
--- a/buildpack/images.go
+++ b/buildpack/images.go
@@ -145,10 +145,12 @@ func (m BuildpackLayerMetadata) metadataAndLayersFor(sourceImage v1.Image, oldId
 type BuildpackLayerMetadata map[string]map[string]BuildpackLayerInfo
 
 type BuildpackLayerInfo struct {
-	API         string  `json:"api"`
-	Stacks      []Stack `json:"stacks,omitempty"`
-	Order       Order   `json:"order,omitempty"`
-	LayerDiffID string  `json:"layerDiffID"`
+	API         string      `json:"api"`
+	Stacks      []Stack     `json:"stacks,omitempty"`
+	Order       Order       `json:"order,omitempty"`
+	LayerDiffID string      `json:"layerDiffID"`
+	Name        string      `json:"name,omitempty"`
+	Homepage    interface{} `json:"homepage,omitempty"`
 }
 
 type Order []OrderEntry
@@ -174,6 +176,7 @@ type Stack struct {
 
 type Metadata struct {
 	Id          string      `json:"id"`
+	Name        string      `json:"name,omitempty"`
 	Version     string      `json:"version,omitempty"`
 	Homepage    interface{} `json:"homepage,omitempty"`
 	Description interface{} `json:"description,omitempty"`


### PR DESCRIPTION
## Summary

Ensures that all metadata is propagated through the image copy & re-id process.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
