### PR TITLE
Adds flag to update the version

### DIFF
--- a/cmd/update-buildpack-image-id/main.go
+++ b/cmd/update-buildpack-image-id/main.go
@@ -14,6 +14,7 @@ func main() {
 	image := flagSet.String("image", "", "The exisiting buildpack image")
 	newImage := flagSet.String("new-image", "", "The new buildpack image")
 	id := flagSet.String("id", "", "The new id of the buildpack")
+	version := flagSet.String("version", "", "The new version of the buildpack")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		log.Fatal(fmt.Errorf("unable to parse flags\n%w", err))
@@ -31,7 +32,11 @@ func main() {
 		log.Fatal("--id is required")
 	}
 
-	rename, err := buildpack.Rename(*image, *newImage, *id)
+	if *version == "" {
+		log.Fatal("--version is required")
+	}
+
+	rename, err := buildpack.Rename(*image, *newImage, *id, *version)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Previously, update-buildpack-image-id would only allow you to update the id. In some cases, the id and version need to change in sync. For example, if you have buildpack abc v5.4.10, you may want to map that to buildpack xyz v1.0.0. This will now rewrite the metadata such that both the id and the version are updated. The current id and version are pulled from the metadata on the existing buildpack (arg #1) image.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
