### PR TITLE
Fixes ibm-semeru update action

### DIFF
--- a/actions/ibm-semeru-dependency/main.go
+++ b/actions/ibm-semeru-dependency/main.go
@@ -121,18 +121,16 @@ func main() {
 		panic(fmt.Errorf("unable to create outputs\n%w", err))
 	}
 
-	if latestVersion.Major() == 8 {
-		// IBM Semeru uses the OpenJ9 version in the CPE, ex: 0.29.1
-		//
-		// This adjusts the update job to set the CPE in this way instead
-		// of using the standard version format
-		re = regexp.MustCompile(`openj9-([\d]+\.[\d]+\.[\d]+).*?\/`)
-		matches := re.FindStringSubmatch(url)
-		if matches == nil || len(matches) != 2 {
-			panic(fmt.Errorf("unable to parse OpenJ9 version: %s", matches))
-		}
-		outputs["cpe"] = matches[1]
+	// IBM Semeru uses the OpenJ9 version in the CPE, ex: 0.29.1
+	//
+	// This adjusts the update job to set the CPE in this way instead
+	// of using the standard version format
+	re = regexp.MustCompile(`openj9-([\d]+\.[\d]+\.[\d]+).*?\/`)
+	matches := re.FindStringSubmatch(url)
+	if matches == nil || len(matches) != 2 {
+		panic(fmt.Errorf("unable to parse OpenJ9 version: %s", matches))
 	}
+	outputs["cpe"] = matches[1]
 
 	outputs.Write(os.Stdout)
 }


### PR DESCRIPTION
## Summary

The action was not writing CPE information for Java 11 & 17. It should have been & this PR enables that.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
