### PR TITLE
Pull in the Skywalking agent not the server

### DIFF
--- a/actions/skywalking-dependency/main.go
+++ b/actions/skywalking-dependency/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	inputs := actions.NewInputs()
 
-	uri := "https://archive.apache.org/dist/skywalking"
+	uri := "https://archive.apache.org/dist/skywalking/java-agent"
 
 	c := colly.NewCollector()
 
@@ -39,7 +39,7 @@ func main() {
 		if p := cp.FindStringSubmatch(element.Attr("href")); p != nil {
 			v := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
 
-			versions[v] = fmt.Sprintf("%s/%[2]s/apache-skywalking-apm-%[2]s.tar.gz", uri, v)
+			versions[v] = fmt.Sprintf("%s/%[2]s/apache-skywalking-java-agent-%[2]s.tgz", uri, v)
 		}
 	})
 


### PR DESCRIPTION
## Summary

The action was previously looking at versions for the Skywalking APM Server, not the Java Agent. This change points it to the Java agent specifically.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
