### PR TITLE
Fixes edge case where versions have prerelease info

### DIFF
--- a/actions/cf-java-index-dependency/main.go
+++ b/actions/cf-java-index-dependency/main.go
@@ -20,15 +20,18 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/paketo-buildpacks/pipeline-builder/actions"
 	"gopkg.in/yaml.v3"
 )
 
+var versionPattern = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)_(.*)`)
+
 func main() {
 	inputs := actions.NewInputs()
 
-    // same repository_root as documented here: https://github.com/cloudfoundry/java-buildpack/blob/main/docs/extending-repositories.md
+	// same repository_root as documented here: https://github.com/cloudfoundry/java-buildpack/blob/main/docs/extending-repositories.md
 	repositoryRoot, ok := inputs["repository_root"]
 	if !ok {
 		panic(fmt.Errorf("repository_root must be specified"))
@@ -52,7 +55,7 @@ func main() {
 
 	versions := make(actions.Versions)
 	for k, v := range raw {
-		versions[k] = v
+		versions[versionPattern.ReplaceAllString(k, "$1.$2.$3-$4")] = v
 	}
 
 	if o, err := versions.GetLatest(inputs); err != nil {


### PR DESCRIPTION
## Summary

Prior to this PR, if a version key in the index.yml had prerelease info, there would be an `_` and then the prerelease info. This isn't valid semver, so it would break the pipeline. This change replaces the `_` with a `-` which makes it valid semver.

## Use Cases

Fixes broken runs like https://github.com/pivotal-cf/tanzu-appdynamics/runs/4732140660?check_suite_focus=true

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
