### PR TITLE
Fixed sbom-formats toml field being ignored during rewrite of image

### DIFF
--- a/buildpack/images.go
+++ b/buildpack/images.go
@@ -24,7 +24,7 @@ func Rename(buildpack, tag, newID, newVersion string) (string, error) {
 
 	image, err := remote.Image(reference, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		return "", fmt.Errorf("unable to feth remote image\n%w", err)
+		return "", fmt.Errorf("unable to fetch remote image\n%w", err)
 	}
 
 	metadata := Metadata{}

--- a/buildpack/rewriteLayer.go
+++ b/buildpack/rewriteLayer.go
@@ -100,10 +100,13 @@ type BuildpackDescriptor struct {
 }
 
 type BuildpackTomlInfo struct {
-	ID       string `toml:"id"`
-	Version  string `toml:"version"`
-	Name     string `toml:"name"`
-	ClearEnv bool   `toml:"clear-env,omitempty"`
+	ID          string   `toml:"id"`
+	Version     string   `toml:"version"`
+	Name        string   `toml:"name"`
+	ClearEnv    bool     `toml:"clear-env,omitempty"`
+	SBOMFormats []string `toml:"sbom-formats,omitempty"`
+	Description string   `toml:"description,omitempty"`
+	Homepage    string   `toml:"homepage,omitempty"`
 }
 
 func escapedID(id string) string {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR fixes an issue with the `update-buildpack-image-id` package usage where the field `sbom-formats` in `buildpack.toml` is not re-written as part of the image 'Rename' functionality.  The field `sbom-formats` was added to the expected fields for a `buildpack.toml`'s buildpack entry. The fields `homepage` and `description` were also added for completeness when rewriting.

## Use Cases
When `update-buildpack-image-id` is called to republish an image as a -lite version, the missing `sbom-formats` field in the buildpack.toml means the SBOM info is not written to the image layer as expected.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
