### PR TITLE
Update Foojay action to filter by libc type

### DIFF
--- a/actions/foojay-dependency/main.go
+++ b/actions/foojay-dependency/main.go
@@ -88,6 +88,7 @@ func LoadPackages(d string, t string, v int) actions.Versions {
 			"archive_type=tar.gz&"+
 			"package_type=%s&"+
 			"operating_system=linux&"+
+			"lib_c_type=glibc&"+
 			"javafx_bundled=false&"+
 			"version=%d..%%3C%d", // 11..<12
 		url.PathEscape(d), t, v, v+1)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Microsoft OpenJDK needs an extra API field to filter by in order to distinguish between Alpine & Linux downloads - Added `lib_c_type = glibc` to the request to match Linux

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
