### PR TITLE
Add a tomee-dependency action to track apache-tomee

### DIFF
--- a/.github/workflows/create-action-tomee-dependency.yml
+++ b/.github/workflows/create-action-tomee-dependency.yml
@@ -1,0 +1,55 @@
+name: Create Action tomee-dependency
+"on":
+    pull_request:
+        paths:
+            - actions/*
+            - actions/tomee-dependency/*
+    push:
+        branches:
+            - main
+        paths:
+            - actions/*
+            - actions/tomee-dependency/*
+    release:
+        types:
+            - published
+jobs:
+    create-action:
+        name: Create Action
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - name: Docker login ghcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v1
+              with:
+                password: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                registry: ghcr.io
+                username: ${{ secrets.JAVA_GITHUB_USERNAME }}
+            - uses: actions/checkout@v2
+            - name: Create Action
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "::group::Building ${TARGET}:${VERSION}"
+                  docker build \
+                    --file actions/Dockerfile \
+                    --build-arg "SOURCE=${SOURCE}" \
+                    --tag "${TARGET}:${VERSION}" \
+                    .
+                echo "::endgroup::"
+
+                if [[ "${PUSH}" == "true" ]]; then
+                  echo "::group::Pushing ${TARGET}:${VERSION}"
+                    docker push "${TARGET}:${VERSION}"
+                  echo "::endgroup::"
+                else
+                  echo "Skipping push"
+                fi
+              env:
+                PUSH: ${{ github.event_name != 'pull_request' }}
+                SOURCE: tomee-dependency
+                TARGET: ghcr.io/paketo-buildpacks/actions/tomee-dependency
+                VERSION: main

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The Pipeline Builder is a collection of tools related to GitHub Actions and othe
     - [Skywalking Dependency](#skywalking-dependency)
     - [Spring Generations](#spring-generations)
     - [Tomcat Dependency](#tomcat-dependency)
+    - [Tomee Dependency](#tomee-dependency)
     - [YourKit Dependency](#yourkit-dependency)
   - [License](#license)
 
@@ -547,6 +548,16 @@ uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
 with:
   uri: https://archive.apache.org/dist/tomcat/tomcat-9
 ```
+
+### Tomee Dependency
+The Tomee Dependency watches the [Apache Tomee Download Page](https://archive.apache.org/dist/tomee/) for new versions. Available distributions are `microprofile`, `webprofile`, `plus` or `plume`
+
+```yaml
+uses: docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
+with:
+  uri: https://archive.apache.org/dist/tomee/
+  dist: webprofile
+```  
 
 ### YourKit Dependency
 The YourKit Dependency watches the [YourKit Download Page](https://www.yourkit.com/java/profiler/download) for new versions.

--- a/actions/action.go
+++ b/actions/action.go
@@ -52,7 +52,7 @@ func NewOutputs(uri string, latestVersion *semver.Version, additionalOutputs Out
 	outputs := Outputs{
 		"sha256":  sha256,
 		"uri":     uri,
-		"version": fmt.Sprintf("%d.%d.%d", latestVersion.Major(), latestVersion.Minor(), latestVersion.Patch()),
+		"version": latestVersion.String(),
 	}
 
 	for k, v := range additionalOutputs {

--- a/actions/tomee-dependency/main.go
+++ b/actions/tomee-dependency/main.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/gocolly/colly"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+var TomeeVersionPattern = regexp.MustCompile(`^tomee-?([\d]+)\.?([\d]+)?\.?([\d]+)?[-+.]?(.*)/$`)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	uri, ok := inputs["uri"]
+	if !ok {
+		panic(fmt.Errorf("uri must be specified"))
+	}
+
+	dist, ok := inputs["dist"]
+	if !ok {
+		dist = "webprofile"
+	}
+
+	major, ok := inputs["major"]
+	if !ok {
+		major = ""
+	}
+
+	c := colly.NewCollector()
+
+	versions := make(actions.Versions)
+	c.OnHTML("a[href]", func(element *colly.HTMLElement) {
+		if p := TomeeVersionPattern.FindStringSubmatch(element.Attr("href")); p != nil {
+			if major == "" || major == p[1] {
+				v := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
+				if p[4] != "" {
+					v = fmt.Sprintf("%s-%s", v, p[4])
+				}
+
+				versions[v] = fmt.Sprintf("%s/tomee-%[2]s/apache-tomee-%[2]s-%s.tar.gz", uri, v, dist)
+
+				fmt.Println("Adding", v, "with url", versions[v])
+			}
+		}
+	})
+
+	if err := c.Visit(uri); err != nil {
+		panic(err)
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary
New `apache-tomee` releases are displayed on the page https://archive.apache.org/dist/tomee, we need to parse the html to be able to get the correct link to download the latest version and sha256.

## Use Cases
Currently working on an Apache Tomee buildpack that I'd like to get moved across to paketo buildpacks.  The tomee dependencies need to be updated in a similar way to the tomcat-dependency action.

Notes for the reviewer:
Tomee v9 is pre-release only, I've had to change how the version is outputted to use the full version rather than `major.minor.patch` - I'm not entirely sure how pre-releases were working before this?

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
