### PR TITLE
Switch to using new Apache download mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ with:
 ```
 
 ### Skywalking Dependency
-The Skywalking Dependency watches the [Apache Skywalking Download Page](https://archive.apache.org/dist/skywalking) for new versions.
+The Skywalking Dependency watches the [Apache Skywalking Download Page](https://downloads.apache.org/skywalking) for new versions.
 
 ```yaml
 uses: docker://ghcr.io/paketo-buildpacks/actions/skywalking-dependency:main
@@ -541,22 +541,23 @@ with:
 ```
 
 ### Tomcat Dependency
-The Tomcat Dependency watches the [Apache Tomcat Download Page](https://archive.apache.org/dist/tomcat/tomcat-9/) for new versions.
+The Tomcat Dependency watches the [Apache Tomcat Download Page](https://downloads.apache.org/tomcat/tomcat-9/) for new versions.
 
 ```yaml
 uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
 with:
-  uri: https://archive.apache.org/dist/tomcat/tomcat-9
+  uri: https://downloads.apache.org/tomcat/tomcat-9
 ```
 
 ### Tomee Dependency
-The Tomee Dependency watches the [Apache Tomee Download Page](https://archive.apache.org/dist/tomee/) for new versions. Available distributions are `microprofile`, `webprofile`, `plus` or `plume`
+The Tomee Dependency watches the [Apache Tomee Download Page](https://downloads.apache.org/tomee/) for new versions. Available distributions are `microprofile`, `webprofile`, `plus` or `plume`.
 
 ```yaml
 uses: docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
 with:
-  uri: https://archive.apache.org/dist/tomee/
+  uri: https://downloads.apache.org/tomee/
   dist: webprofile
+  major: 9
 ```  
 
 ### YourKit Dependency

--- a/actions/skywalking-dependency/main.go
+++ b/actions/skywalking-dependency/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	inputs := actions.NewInputs()
 
-	uri := "https://archive.apache.org/dist/skywalking/java-agent"
+	uri := "https://downloads.apache.org/skywalking/java-agent"
 
 	c := colly.NewCollector()
 

--- a/actions/tomee-dependency/main.go
+++ b/actions/tomee-dependency/main.go
@@ -58,8 +58,6 @@ func main() {
 				}
 
 				versions[v] = fmt.Sprintf("%s/tomee-%[2]s/apache-tomee-%[2]s-%s.tar.gz", uri, v, dist)
-
-				fmt.Println("Adding", v, "with url", versions[v])
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

Switches to using https://downloads.apache.org/ from https://archive.apache.org. This is the new CDN for Apache projects and is supposed to sync more quickly afte projects release, which should result in us getting updates more quickly.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
