### PR TITLE
Revert version format change

### DIFF
--- a/actions/action.go
+++ b/actions/action.go
@@ -52,7 +52,7 @@ func NewOutputs(uri string, latestVersion *semver.Version, additionalOutputs Out
 	outputs := Outputs{
 		"sha256":  sha256,
 		"uri":     uri,
-		"version": latestVersion.String(),
+		"version": fmt.Sprintf("%d.%d.%d", latestVersion.Major(), latestVersion.Minor(), latestVersion.Patch()),
 	}
 
 	for k, v := range additionalOutputs {


### PR DESCRIPTION
## Summary

Reverts version format change introduced with https://github.com/paketo-buildpacks/pipeline-builder/commit/a0c5b6f3e8dd0720f0b1941c47b5ff0ce3486fb5.

We can't make that change at this time as it impacts other buildpacks.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
