### PR TITLE
Add in pre-release information for tomee versions

### DIFF
--- a/actions/tomee-dependency/main.go
+++ b/actions/tomee-dependency/main.go
@@ -66,9 +66,27 @@ func main() {
 		panic(err)
 	}
 
+	latestVersion, err := versions.GetLatestVersion(inputs)
+	if err != nil {
+		panic(err)
+	}
+
 	if o, err := versions.GetLatest(inputs); err != nil {
 		panic(err)
 	} else {
+		// override the version with the full string (including prerelease information)
+		if latestVersion.Prerelease() != "" {
+			o["version"] = latestVersion.String()
+		}
 		o.Write(os.Stdout)
 	}
+}
+
+func GetLatest(v actions.Versions, inputs actions.Inputs, mods ...actions.RequestModifierFunc) (actions.Outputs, error) {
+	latestVersion, err := v.GetLatestVersion(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	return actions.NewOutputs(v[latestVersion.Original()], latestVersion, nil, mods...)
 }


### PR DESCRIPTION
## Summary
Added back in pre-release information in to the tomee dependency checker.  Tomee versioning appears to follow the same process as Tomcat versioning where we can expect both `9.0.0` and `9.0.0-M7` versions to exist at the same time. 

e.g. with Tomcat we have:

https://archive.apache.org/dist/tomcat/tomcat-10/v10.0.0-M9/ and https://archive.apache.org/dist/tomcat/tomcat-10/v10.0.0/

Tested locally with:

```
❯ INPUT_URI=https://downloads.apache.org/tomee INPUT_MAJOR=7 go run actions/tomee-dependency/main.go
::set-output name=sha256::ee4fd96e0b308b40325c32376e4179d1620791fc76e38943d7337b409f445d3e
::set-output name=uri::https://downloads.apache.org/tomee/tomee-7.1.4/apache-tomee-7.1.4-webprofile.tar.gz
::set-output name=version::7.1.4
❯ INPUT_URI=https://downloads.apache.org/tomee INPUT_MAJOR=8 go run actions/tomee-dependency/main.go
::set-output name=sha256::5f64747ddd17187a8064807e6bd548773041921b0769e708357bb79f07f18a28
::set-output name=uri::https://downloads.apache.org/tomee/tomee-8.0.9/apache-tomee-8.0.9-webprofile.tar.gz
::set-output name=version::8.0.9
❯ INPUT_URI=https://downloads.apache.org/tomee INPUT_MAJOR=9 go run actions/tomee-dependency/main.go
::set-output name=sha256::a083775996a56fbb3830f549b18b6c9b9ed42e82aac9af2e1abc719e13782b0f
::set-output name=uri::https://downloads.apache.org/tomee/tomee-9.0.0-M7/apache-tomee-9.0.0-M7-webprofile.tar.gz
::set-output name=version::9.0.0-M7
```
## Use Cases
This PR will allow us to determine the difference between a 9.0.0 and 9.0.0-M7 release

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

fyi @dmikusa-pivotal 
