### PR TITLE
Bump golang to 1.17

### DIFF
--- a/octo/octo.go
+++ b/octo/octo.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	CraneVersion  = "0.6.0"
-	GoVersion     = "1.16"
+	GoVersion     = "1.17"
 	PackVersion   = "0.21.1"
 	RichGoVersion = "0.3.9"
 	YJVersion     = "5.0.0"


### PR DESCRIPTION
with the golang 1.18 imminent release, 1.16 will no longer be supported.

https://endoflife.date/go

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Bump golang version in pipelines to 1.17

## Use Cases
Golang 1.16 will not be supported with the release of 1.18 (soon)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
