### PR TITLE
Updated regex for matching unzipped JDK dir

### DIFF
--- a/actions/alibaba-dragonwell-dependency/main.go
+++ b/actions/alibaba-dragonwell-dependency/main.go
@@ -152,7 +152,7 @@ func GetVersion(assets []*github.ReleaseAsset) string {
 
 	t := tar.NewReader(gz)
 
-	re = regexp.MustCompile(`jdk[^/]+/release`)
+	re = regexp.MustCompile(`(dragonwell|jdk)[^/]+/release`)
 	for {
 		f, err := t.Next()
 		if err != nil && err == io.EOF {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Dragonwell changed the name of the dir that is zipped to create the JDK download, this PR updates the regex to match the old or the new name.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
