### PR TITLE
add liberty action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The Pipeline Builder is a collection of tools related to GitHub Actions and othe
     - [JProfiler Dependency](#jprofiler-dependency)
     - [JRebel Dependency](#jrebel-dependency)
     - [Leiningen Dependency](#leiningen-dependency)
+    - [Liberty Dependency](#liberty-dependency)
     - [Maven Dependency](#maven-dependency)
     - [New Relic Dependency](#new-relic-dependency)
     - [NPM Dependency](#npm-dependency)

--- a/actions/liberty-dependency/main.go
+++ b/actions/liberty-dependency/main.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	u, ok := inputs["uri"]
+	if !ok {
+		panic(fmt.Errorf("uri must be specified"))
+	}
+
+	g, ok := inputs["group_id"]
+	if !ok {
+		panic(fmt.Errorf("group_id must be specified"))
+	}
+
+	a, ok := inputs["artifact_id"]
+	if !ok {
+		panic(fmt.Errorf("artifact_id must be specified"))
+	}
+
+	uri := fmt.Sprintf("%s/%s/%s/maven-metadata.xml", u, strings.ReplaceAll(g, ".", "/"), a)
+
+	resp, err := http.Get(uri)
+	if err != nil {
+		panic(fmt.Errorf("unable to get %s\n%w", uri, err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		panic(fmt.Errorf("unable to download %s: %d", uri, resp.StatusCode))
+	}
+
+	var raw Metadata
+	if err := xml.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		panic(fmt.Errorf("unable to decode payload\n%w", err))
+	}
+
+	versions := make(actions.Versions)
+	for _, v := range raw.Versioning.Versions {
+		w := fmt.Sprintf("%s/%s/%s/%s", u, strings.ReplaceAll(g, ".", "/"), a, v)
+		w = fmt.Sprintf("%s/%s-%s", w, a, v)
+		if s, ok := inputs["classifier"]; ok {
+			w = fmt.Sprintf("%s-%s", w, s)
+		}
+		if s, ok := inputs["packaging"]; ok {
+			w = fmt.Sprintf("%s.%s", w, s)
+		} else {
+			w = fmt.Sprintf("%s.jar", w)
+		}
+
+		n, err := actions.NormalizeVersion(v)
+		if err != nil {
+			panic(err)
+		}
+
+		versions[n] = w
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}
+
+var ExtendedVersionPattern = regexp.MustCompile(`^v?([\d]+)\.?([\d]+)?\.?([\d]+)?[-+.]?(.*)$`)
+
+func NormalizeVersion(raw string) (string, error) {
+	if p := ExtendedVersionPattern.FindStringSubmatch(raw); p != nil {
+		for i := 1; i < 4; i++ {
+			if p[i] == "" {
+				p[i] = "0"
+			}
+		}
+
+		s := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[4])
+
+		return s, nil
+	}
+
+	return "", fmt.Errorf("unable to parse %s as a extended version (%s)", raw, ExtendedVersionPattern)
+}	
+
+type Metadata struct {
+	Versioning Versioning `xml:"versioning"`
+}
+
+type Versioning struct {
+	Versions []string `xml:"versions>version"`
+}

--- a/actions/liberty-dependency/main.go
+++ b/actions/liberty-dependency/main.go
@@ -74,7 +74,7 @@ func main() {
 			w = fmt.Sprintf("%s.jar", w)
 		}
 
-		n, err := actions.NormalizeVersion(v)
+		n, err := NormalizeVersion(v)
 		if err != nil {
 			panic(err)
 		}
@@ -93,7 +93,7 @@ var ExtendedVersionPattern = regexp.MustCompile(`^v?([\d]+)\.?([\d]+)?\.?([\d]+)
 
 func NormalizeVersion(raw string) (string, error) {
 	if p := ExtendedVersionPattern.FindStringSubmatch(raw); p != nil {
-		for i := 1; i < 4; i++ {
+		for i := 1; i < 5; i++ {
 			if p[i] == "" {
 				p[i] = "0"
 			}

--- a/actions/liberty-dependency/main.go
+++ b/actions/liberty-dependency/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/paketo-buildpacks/pipeline-builder/actions"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Create custom action for the liberty buildpack to change how versions are handled.  The action was copied from the maven-dependency action. 

## Use Cases
<!-- An explanation of the use cases your change enables -->
The liberty versions are like, 22.0.0.2 and doesn't conform to the standard semver.  Liberty is on a 4-week delivery cycle that increments the last number.  The first number is the year.   The current generic maven action smushes the version to 22.0.0.  This custom builder smushes it to 22.0.2.  This change will allow the buildpack to have multiple versions.  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
