### PR TITLE
Adjust cron schedule for package dependencies

### DIFF
--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -126,7 +126,7 @@ func contributePackageDependency(descriptor Descriptor, name string, bpId string
 	w := actions.Workflow{
 		Name: fmt.Sprintf("Update %s", filepath.Base(name)),
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "12-23", DayOfWeek: "1-5"}},
+			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "4", DayOfWeek: "3-4"}},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{


### PR DESCRIPTION
## Summary

At present, we are checking for package dependency updates M-F from 7-5PM EST. These are updates that bump dependency buildpacks in the composite buildpacks. Since we are only releasing composite buildpacks on Friday, we don't really need to run these update jobs all week. We also don't really need to run them every hour.

The new plan is to have them run early morning UTC. This means that the jobs will have run after any changes we made Wed or Thu, and we should hopefully have all PRs ready to be merged on Friday.

If there are out-of-band updates required, then a manual trigger of the update jobs could be done using the `gh` cli.

## Use Cases

Reduce the waste generated by checking for updates all the time. Reduce contention for limited resources around Github Action Runners.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
