### PR TITLE
Add tomee-dependency to pipeline-descriptor

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -74,5 +74,7 @@ actions:
   target: ghcr.io/paketo-buildpacks/actions/spring-generations
 - source: tomcat-dependency
   target: ghcr.io/paketo-buildpacks/actions/tomcat-dependency
+- source: tomee-dependency
+  target: ghcr.io/paketo-buildpacks/actions/tomee-dependency
 - source: yourkit-dependency
   target: ghcr.io/paketo-buildpacks/actions/yourkit-dependency


### PR DESCRIPTION
## Summary
The tomee-dependency is missing from the pipeline-descriptor, I didn't realise this was required when I created the tomee-dependency.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
