### PR TITLE
Fix loading version

### DIFF
--- a/actions/draft-release/main.go
+++ b/actions/draft-release/main.go
@@ -87,9 +87,9 @@ func main() {
 	}
 
 	if _, dryRun := inputs["dry_run"]; dryRun {
-		fmt.Println("Title:", name)
-		fmt.Println("Body:", body)
-		fmt.Println("Would execute EditRelease with:")
+		fmt.Println("Title: ", name)
+		fmt.Println("Body: ", body)
+		fmt.Println("Would execute EditRelease with: ")
 		fmt.Println("    ", owner)
 		fmt.Println("    ", repo)
 		fmt.Println("    ", releaseId)

--- a/drafts/drafts.go
+++ b/drafts/drafts.go
@@ -352,20 +352,17 @@ func (g GithubBuildpackLoader) LoadBuildpack(imgUri string) (Buildpack, error) {
 		}
 
 		if len(tomlBytes) > 0 {
-			break
+			bp, err := loadBuildpackTOML(tomlBytes)
+			if err != nil {
+				return Buildpack{}, fmt.Errorf("unable to load buildpack toml from image\n%w", err)
+			}
+
+			bp.Info.Version = parts[3]
+			return *bp, nil
 		}
 	}
 
-	if len(tomlBytes) == 0 {
-		return Buildpack{}, fmt.Errorf("unable to fetch toml, file not found")
-	}
-
-	bp, err := loadBuildpackTOML(tomlBytes)
-	if err != nil {
-		return Buildpack{}, fmt.Errorf("unable to load buildpack toml from image\n%w", err)
-	}
-
-	return *bp, nil
+	return Buildpack{}, fmt.Errorf("unable to load buildpack.toml for %s", imgUri)
 }
 
 func (g GithubBuildpackLoader) mapURIs(uri string) ([]string, error) {

--- a/integration/drafts_test.go
+++ b/integration/drafts_test.go
@@ -42,6 +42,7 @@ func testDrafts(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(bp.Info.ID).To(Equal("paketo-buildpacks/bellsoft-liberica"))
+			Expect(bp.Info.Version).ToNot(ContainSubstring("{{.version}}"))
 			Expect(bp.Dependencies).ToNot(BeEmpty())
 			Expect(bp.OrderGroups).To(BeEmpty())
 			Expect(bp.Stacks).ToNot(BeEmpty())
@@ -59,6 +60,7 @@ func testDrafts(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(bp.Info.ID).To(Equal("paketo-buildpacks/bellsoft-liberica"))
+			Expect(bp.Info.Version).ToNot(ContainSubstring("{{.version}}"))
 			Expect(bp.Dependencies).ToNot(BeEmpty())
 			Expect(bp.OrderGroups).To(BeEmpty())
 			Expect(bp.Stacks).ToNot(BeEmpty())
@@ -75,7 +77,7 @@ func testDrafts(t *testing.T, context spec.G, it spec.S) {
 				GithubClient: github.NewClient(http.DefaultClient),
 			}.LoadBuildpack("gcr.io/paketo-buildpacks/does-not-exist:main")
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(HavePrefix("unable to fetch toml, file not found")))
+			Expect(err).To(MatchError(HavePrefix("unable to load buildpack.toml for gcr.io/paketo-buildpacks/does-not-exist:main")))
 		})
 	})
 }


### PR DESCRIPTION
## Summary

Don't load the version from the buildpack.toml, where it is not set. Instead, just use the version that we use to look up the buildpack.toml.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
