### PR TITLE
Adds compute-artifact-description action

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -32,6 +32,8 @@ actions:
   target: ghcr.io/paketo-buildpacks/actions/cf-java-index-dependency
 - source: clojure-tools-dependency
   target: ghcr.io/paketo-buildpacks/actions/clojure-tools-dependency
+- source: compute-artifact-description
+  target: ghcr.io/paketo-buildpacks/actions/compute-artifact-description
 - source: draft-release
   target: ghcr.io/paketo-buildpacks/actions/draft-release
 - source: foojay-dependency

--- a/.github/workflows/create-action-compute-artifact-description.yml
+++ b/.github/workflows/create-action-compute-artifact-description.yml
@@ -1,0 +1,55 @@
+name: Create Action compute-artifact-description
+"on":
+    pull_request:
+        paths:
+            - actions/*
+            - actions/compute-artifact-description/*
+    push:
+        branches:
+            - main
+        paths:
+            - actions/*
+            - actions/compute-artifact-description/*
+    release:
+        types:
+            - published
+jobs:
+    create-action:
+        name: Create Action
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - name: Docker login ghcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v1
+              with:
+                password: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                registry: ghcr.io
+                username: ${{ secrets.JAVA_GITHUB_USERNAME }}
+            - uses: actions/checkout@v3
+            - name: Create Action
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "::group::Building ${TARGET}:${VERSION}"
+                  docker build \
+                    --file actions/Dockerfile \
+                    --build-arg "SOURCE=${SOURCE}" \
+                    --tag "${TARGET}:${VERSION}" \
+                    .
+                echo "::endgroup::"
+
+                if [[ "${PUSH}" == "true" ]]; then
+                  echo "::group::Pushing ${TARGET}:${VERSION}"
+                    docker push "${TARGET}:${VERSION}"
+                  echo "::endgroup::"
+                else
+                  echo "Skipping push"
+                fi
+              env:
+                PUSH: ${{ github.event_name != 'pull_request' }}
+                SOURCE: compute-artifact-description
+                TARGET: ghcr.io/paketo-buildpacks/actions/compute-artifact-description
+                VERSION: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
             - ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                 path: ${{ env.HOME }}/go/pkg/mod
                 restore-keys: ${{ runner.os }}-go-
-            - uses: actions/setup-go@v2
+            - uses: actions/setup-go@v3
               with:
                 go-version: "1.17"
             - name: Install create-package
@@ -90,12 +90,12 @@ jobs:
             - ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                 path: ${{ env.HOME }}/go/pkg/mod
                 restore-keys: ${{ runner.os }}-go-
-            - uses: actions/setup-go@v2
+            - uses: actions/setup-go@v3
               with:
                 go-version: "1.17"
             - name: Install richgo

--- a/.github/workflows/update-pipeline.yml
+++ b/.github/workflows/update-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v2
+            - uses: actions/setup-go@v3
               with:
                 go-version: "1.17"
             - name: Install octo
@@ -62,7 +62,7 @@ jobs:
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
                 GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
-            - uses: peter-evans/create-pull-request@v3
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-

--- a/actions/compute-artifact-description/main.go
+++ b/actions/compute-artifact-description/main.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/google/go-github/v43/github"
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+	"github.com/paketo-buildpacks/pipeline-builder/drafts"
+	"golang.org/x/oauth2"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	var c *http.Client
+	if s, ok := inputs["github_token"]; ok {
+		c = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s}))
+	}
+	gh := github.NewClient(c)
+
+	loader := drafts.GithubBuildpackLoader{
+		GithubClient: gh,
+		RegexMappers: parseMappers(inputs),
+	}
+
+	mainBp, err := loader.LoadBuildpack(inputs["package"])
+	if err != nil {
+		panic(err)
+	}
+
+	depsMap := map[string]bool{}
+	if len(mainBp.OrderGroups) > 0 {
+		pkg, err := loader.LoadPackages(inputs["package"])
+		if err != nil {
+			panic(err)
+		}
+
+		bps := []drafts.Buildpack{}
+		for _, depBp := range pkg.Dependencies {
+			bp, err := loader.LoadBuildpack(depBp.URI)
+			if err != nil {
+				panic(fmt.Errorf("unable to load %s\n%w", depBp.URI, err))
+			}
+			bps = append(bps, bp)
+		}
+
+		for _, bp := range bps {
+			for _, dep := range bp.Dependencies {
+				depsMap[fmt.Sprintf("%s %s", dep.Name, dep.Version)] = true
+			}
+		}
+	} else {
+		for _, dep := range mainBp.Dependencies {
+			depsMap[fmt.Sprintf("%s %s", dep.Name, dep.Version)] = true
+		}
+	}
+
+	deps := []string{}
+	for dep := range depsMap {
+		deps = append(deps, dep)
+	}
+	sort.Strings(deps)
+
+	fmt.Printf("::set-output name=artifact-reference-description::%s", strings.Join(deps, "%0A")) // linefeed
+}
+
+func parseMappers(inputs actions.Inputs) []string {
+	mappers := []string{}
+
+	for key, val := range inputs {
+		if strings.HasPrefix(key, "mapper_") {
+			mappers = append(mappers, val)
+		}
+	}
+
+	return mappers
+}


### PR DESCRIPTION
## Summary

This action will go through and compute a list of all the dependencies used by the buildpack. It is recursive, so if you point it to a composite buildpack, it'll pull all of the dependencies for every buildpack included in that composite buildpack and give one list, sorted and with duplicates removed.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
