### PR TITLE
Add version to compute artifact action

### DIFF
--- a/actions/compute-artifact-description/main.go
+++ b/actions/compute-artifact-description/main.go
@@ -33,6 +33,17 @@ import (
 func main() {
 	inputs := actions.NewInputs()
 
+	if _, found := inputs["package"]; !found {
+		panic(fmt.Errorf("unable to read package, package must be set"))
+	}
+
+	if _, found := inputs["version"]; !found {
+		panic(fmt.Errorf("unable to read version, version must be set"))
+	}
+
+	imgUri := fmt.Sprintf("%s:%s", inputs["package"], inputs["version"])
+	fmt.Println("Loading image URI:", imgUri)
+
 	var c *http.Client
 	if s, ok := inputs["github_token"]; ok {
 		c = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s}))
@@ -44,7 +55,7 @@ func main() {
 		RegexMappers: parseMappers(inputs),
 	}
 
-	mainBp, err := loader.LoadBuildpack(inputs["package"])
+	mainBp, err := loader.LoadBuildpack(imgUri)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

The compute artifact action needs the version. The workflows that use it, keep the version as a separate value not part of the package URI. This allows it to be passed in as a separate parameter, 'version'.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
