### PR TITLE
Sort by Strings is not totally accurate

### DIFF
--- a/actions/alibaba-dragonwell-dependency/main.go
+++ b/actions/alibaba-dragonwell-dependency/main.go
@@ -17,16 +17,12 @@
 package main
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
-	"sort"
+	"strings"
 
 	"github.com/google/go-github/v43/github"
 	"golang.org/x/oauth2"
@@ -38,17 +34,17 @@ func main() {
 	inputs := actions.NewInputs()
 
 	var (
-		err error
-		g   *regexp.Regexp
+		err       error
+		globRegex *regexp.Regexp
 	)
 	// regex to match asset names from github releases
 	if s, ok := inputs["glob"]; ok {
-		g, err = regexp.Compile(s)
+		globRegex, err = regexp.Compile(s)
 		if err != nil {
 			panic(fmt.Errorf("unable to compile %s as a regexp\n%w", s, err))
 		}
 	} else {
-		g = regexp.MustCompile(".+")
+		globRegex = regexp.MustCompile(".+")
 	}
 
 	// github repo under the `alibaba` org to watch
@@ -63,9 +59,8 @@ func main() {
 	}
 	gh := github.NewClient(c)
 
-	candidates := make(map[string]Holder)
-	var candidateVersions []string
-	re := regexp.MustCompile(`(dragonwell-)?(\d+\.\d+\.\d+\.?\d*).*-(ga|GA)`)
+	tagRegex := regexp.MustCompile(`dragonwell-.*_jdk[-]?(.*)-ga`)
+	versions := actions.Versions{}
 	opt := &github.ListOptions{PerPage: 100}
 	for {
 		rel, rsp, err := gh.Repositories.ListReleases(context.Background(), "alibaba", r, opt)
@@ -74,12 +69,14 @@ func main() {
 		}
 
 		for _, r := range rel {
-			for _, a := range r.Assets {
-				if g.MatchString(*a.Name) {
-					if g := re.FindStringSubmatch(*r.TagName); g != nil {
-						ver := g[2]
-						candidateVersions = append(candidateVersions, ver)
-						candidates[ver] = Holder{Assets: r.Assets, URI: *a.BrowserDownloadURL}
+			if tag := tagRegex.FindStringSubmatch(*r.TagName); tag != nil {
+				for _, a := range r.Assets {
+					if globRegex.MatchString(*a.Name) {
+						version := tag[1]
+						if strings.HasPrefix(tag[1], "8u") {
+							version = fmt.Sprintf("8.0.%s", strings.TrimLeft(version, "8u"))
+						}
+						versions[version] = *a.BrowserDownloadURL
 						break
 					}
 				}
@@ -91,11 +88,6 @@ func main() {
 		}
 		opt.Page = rsp.NextPage
 	}
-
-	sort.Strings(candidateVersions)
-
-	h := candidates[candidateVersions[len(candidateVersions)-1]]
-	versions := actions.Versions{GetVersion(h.Assets): h.URI}
 
 	latestVersion, err := versions.GetLatestVersion(inputs)
 	if err != nil {
@@ -116,78 +108,4 @@ func main() {
 	}
 
 	outputs.Write(os.Stdout)
-}
-
-func GetVersion(assets []*github.ReleaseAsset) string {
-	re := regexp.MustCompile(`Alibaba_Dragonwell_(.+)_x64_linux.tar.gz$`)
-
-	var uri *string
-
-	for _, a := range assets {
-		if re.MatchString(*a.Name) {
-			uri = a.BrowserDownloadURL
-			break
-		}
-	}
-
-	if uri == nil {
-		panic(fmt.Errorf("unable to find asset that matches %s", re.String()))
-	}
-
-	resp, err := http.Get(*uri)
-	if err != nil {
-		panic(fmt.Errorf("unable to get %s\n%w", *uri, err))
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		panic(fmt.Errorf("unable to download %s: %d", *uri, resp.StatusCode))
-	}
-
-	gz, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		panic(fmt.Errorf("unable to create GZIP reader\n%w", err))
-	}
-	defer gz.Close()
-
-	t := tar.NewReader(gz)
-
-	re = regexp.MustCompile(`(dragonwell|jdk)[^/]+/release`)
-	for {
-		f, err := t.Next()
-		if err != nil && err == io.EOF {
-			break
-		} else if err != nil {
-			panic(fmt.Errorf("unable to read TAR file\n%w", err))
-		}
-
-		if !re.MatchString(f.Name) {
-			continue
-		}
-
-		b, err := ioutil.ReadAll(t)
-		if err != nil {
-			panic(fmt.Errorf("unable to read %s\n%w", f.Name, err))
-		}
-
-		var v string
-
-		re = regexp.MustCompile(`JAVA_VERSION="([\d]+)\.([\d]+)\.([\d]+)[\._]?([\d]+)?"`)
-		if g := re.FindStringSubmatch(string(b)); g != nil {
-			if g[2] == "8" {
-				v = fmt.Sprintf("8.0.%s", g[4])
-			} else {
-				v = fmt.Sprintf("%s.%s.%s", g[1], g[2], g[3])
-			}
-		}
-
-		return v
-	}
-
-	panic(fmt.Errorf("unable to find file that matches %s", re.String()))
-}
-
-type Holder struct {
-	Assets []*github.ReleaseAsset
-	URI    string
 }


### PR DESCRIPTION
## Summary

In a couple of the actions, we were sorting an array of string versions. String versions do not sort correctly though under some circumstances, like if you have minor/patch releases in the list that are both less than and greater than 10. You get a sort like 1, 10, 11, 2, 3, 4, etc.. not 1, 2, 3, 4, 10, 11. This can cause updates to be missed.

This PR rewrites the two impacted actions such that they are using Semver to sort and pick the latest order, which guarantees that we get the most recent release. This PR also makes some optimizations so that the version number is loaded from metadata instead of the JVM file, or that we only download and read the version from at least one JVM.

In addition, it removes support for Java 8 from GraalVM, which dropped Java 8 support.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
