### PR TITLE
Action fixes

### DIFF
--- a/actions/alibaba-dragonwell-dependency/main.go
+++ b/actions/alibaba-dragonwell-dependency/main.go
@@ -73,7 +73,7 @@ func main() {
 				for _, a := range r.Assets {
 					if globRegex.MatchString(*a.Name) {
 						version := tag[1]
-						if strings.HasPrefix(tag[1], "8u") {
+						if strings.HasPrefix(version, "8u") {
 							version = fmt.Sprintf("8.0.%s", strings.TrimLeft(version, "8u"))
 						}
 						versions[version] = *a.BrowserDownloadURL

--- a/actions/foojay-dependency/main.go
+++ b/actions/foojay-dependency/main.go
@@ -146,7 +146,7 @@ func LoadPackages(d string, t string, v int) actions.Versions {
 			}
 			versions[version] = LoadDownloadURI(result.Links.URI)
 		} else {
-			fmt.Println(result.JavaVersion, "failed to parse")
+			panic(fmt.Errorf(result.JavaVersion, "failed to parse"))
 		}
 	}
 

--- a/actions/graalvm-dependency/main.go
+++ b/actions/graalvm-dependency/main.go
@@ -111,9 +111,7 @@ func main() {
 
 	url := versions[latestVersion.Original()]
 
-	if productType == JDKProductType {
-		latestVersion = semver.MustParse(GetVersion(url))
-	}
+	latestVersion = semver.MustParse(GetVersion(url))
 
 	outputs, err := actions.NewOutputs(url, latestVersion, nil)
 	if err != nil {
@@ -138,6 +136,9 @@ func main() {
 }
 
 func GetVersion(uri string) string {
+	// for native-image installer, we convert the URL to the graalvm-ce download URL to fetch the version
+	uri = strings.Replace(strings.Replace(uri, ".jar", ".tar.gz", 1), "native-image-installable-svm-", "graalvm-ce-", 1)
+
 	resp, err := http.Get(uri)
 	if err != nil {
 		panic(fmt.Errorf("unable to get %s\n%w", uri, err))
@@ -185,9 +186,4 @@ func GetVersion(uri string) string {
 	}
 
 	panic(fmt.Errorf("unable to find file that matches %s", re.String()))
-}
-
-type Holder struct {
-	Assets []*github.ReleaseAsset
-	URI    string
 }


### PR DESCRIPTION
## Summary

1. Not a bug, but for code clarity consistently use 'version' in dragonwell action
2. Panic when we can't parse a version from the Foojay API. This should not happen, just printing could result in missing errors.
3. Modify graalvm to pull the Java version even for native image installable downloads. This is consistent with past behavior.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
