### PR TITLE
Rollback crane from 0.10.0 to 0.8.0

### DIFF
--- a/octo/octo.go
+++ b/octo/octo.go
@@ -29,7 +29,7 @@ import (
 //go:generate statik -src . -include *.sh
 
 const (
-	CraneVersion  = "0.10.0"
+	CraneVersion  = "0.8.0"
 	GoVersion     = "1.17"
 	PackVersion   = "0.27.0"
 	RichGoVersion = "0.3.10"


### PR DESCRIPTION
Functionality was added in crane to support cross-registry blob mounting, but it seems to cause issues with Harbor registry (and possibly others). Rolling back for stability. We'll need to revisit this in the future.

https://github.com/google/go-containerregistry/pull/1388

To reproduce the problem:

1. `crane cp` an image to a Harbor registry that is not currently in the registry
2. It'll fail saying `Error: failed to copy image: POST` and `UNAUTHORIZED: project foo not found: project foo not found`.

This should be retested before bumping the version of crane.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
