### PR TITLE
Add NewActionContributionWithNamespace and deprecate NewActionContribution

### DIFF
--- a/octo/actions.go
+++ b/octo/actions.go
@@ -74,7 +74,7 @@ func ContributeActions(descriptor Descriptor) ([]Contribution, error) {
 		j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
 		w.Jobs["create-action"] = j
 
-		if c, err := NewActionContribution(w); err != nil {
+		if c, err := NewActionContributionWithNamespace(Namespace, w); err != nil {
 			return nil, err
 		} else {
 			contributions = append(contributions, c)

--- a/octo/builder_dependencies.go
+++ b/octo/builder_dependencies.go
@@ -141,7 +141,7 @@ Bumps %[1]s from ${{ steps.build-image.outputs.old-version }} to ${{ steps.build
 	j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
 	w.Jobs["update"] = j
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }
 
 func contributeLifecycle(descriptor Descriptor) (Contribution, error) {
@@ -211,5 +211,5 @@ Bumps lifecycle from ${{ steps.lifecycle.outputs.old-version }} to ${{ steps.lif
 		},
 	}
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }

--- a/octo/buildpack_dependencies.go
+++ b/octo/buildpack_dependencies.go
@@ -97,7 +97,7 @@ Bumps %[1]s from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpa
 			},
 		}
 
-		if c, err := NewActionContribution(w); err != nil {
+		if c, err := NewActionContributionWithNamespace(Namespace, w); err != nil {
 			return nil, err
 		} else {
 			contributions = append(contributions, c)

--- a/octo/contribution.go
+++ b/octo/contribution.go
@@ -46,9 +46,11 @@ func NewActionContributionWithNamespace(namespace string, workflow actions.Workf
 		err error
 	)
 
-	workflowName := fmt.Sprintf("%s-%s.yml", namespace, strcase.ToKebab(workflow.Name))
+	var workflowName string
 	if namespace == "" {
 		workflowName = fmt.Sprintf("%s.yml", strcase.ToKebab(workflow.Name))
+	} else {
+		workflowName = fmt.Sprintf("%s-%s.yml", namespace, strcase.ToKebab(workflow.Name))
 	}
 
 	c.Path = filepath.Join(".github", "workflows", workflowName)

--- a/octo/contribution.go
+++ b/octo/contribution.go
@@ -37,14 +37,21 @@ type Contribution struct {
 	Permissions os.FileMode
 	Structure   gotree.Tree
 	Content     []byte
+	Namespace   string
 }
 
-func NewActionContribution(workflow actions.Workflow) (Contribution, error) {
+func NewActionContributionWithNamespace(namespace string, workflow actions.Workflow) (Contribution, error) {
 	var (
 		c   Contribution
 		err error
 	)
-	c.Path = filepath.Join(".github", "workflows", fmt.Sprintf("%s.yml", strcase.ToKebab(workflow.Name)))
+
+	workflowName := fmt.Sprintf("%s-%s.yml", namespace, strcase.ToKebab(workflow.Name))
+	if namespace == "" {
+		workflowName = fmt.Sprintf("%s.yml", strcase.ToKebab(workflow.Name))
+	}
+
+	c.Path = filepath.Join(".github", "workflows", workflowName)
 	c.Permissions = 0644
 
 	var t []event.Type
@@ -62,6 +69,11 @@ func NewActionContribution(workflow actions.Workflow) (Contribution, error) {
 	}
 
 	return c, err
+}
+
+// Deprecated: use NewActionContributionWithNamespace instead
+func NewActionContribution(workflow actions.Workflow) (Contribution, error) {
+	return NewActionContributionWithNamespace("", workflow)
 }
 
 func NewDependabotContribution(dependabot dependabot.Dependabot) (Contribution, error) {

--- a/octo/create_builder.go
+++ b/octo/create_builder.go
@@ -89,7 +89,7 @@ func ContributeCreateBuilder(descriptor Descriptor) (*Contribution, error) {
 	j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
 	w.Jobs["create-builder"] = j
 
-	c, err := NewActionContribution(w)
+	c, err := NewActionContributionWithNamespace(Namespace, w)
 	if err != nil {
 		return nil, err
 	}

--- a/octo/create_package.go
+++ b/octo/create_package.go
@@ -161,7 +161,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 	j.Steps = append(NewHttpCredentialActions(descriptor.HttpCredentials), j.Steps...)
 	w.Jobs["create-package"] = j
 
-	c, err := NewActionContribution(w)
+	c, err := NewActionContributionWithNamespace(Namespace, w)
 	if err != nil {
 		return nil, err
 	}

--- a/octo/draft_release.go
+++ b/octo/draft_release.go
@@ -145,7 +145,7 @@ func ContributeDraftRelease(descriptor Descriptor) ([]Contribution, error) {
 		w.Jobs["update"] = j
 	}
 
-	if c, err := NewActionContribution(w); err != nil {
+	if c, err := NewActionContributionWithNamespace(Namespace, w); err != nil {
 		return nil, err
 	} else {
 		contributions = append(contributions, c)

--- a/octo/labels.go
+++ b/octo/labels.go
@@ -107,7 +107,7 @@ func ContributeLabels(descriptor Descriptor) ([]Contribution, error) {
 		},
 	}
 
-	if c, err := NewActionContribution(w); err != nil {
+	if c, err := NewActionContributionWithNamespace(Namespace, w); err != nil {
 		return nil, err
 	} else {
 		contributions = append(contributions, c)
@@ -168,7 +168,7 @@ func ContributeLabels(descriptor Descriptor) ([]Contribution, error) {
 		},
 	}
 
-	if c, err := NewActionContribution(w); err != nil {
+	if c, err := NewActionContributionWithNamespace(Namespace, w); err != nil {
 		return nil, err
 	} else {
 		contributions = append(contributions, c)

--- a/octo/lite_packages.go
+++ b/octo/lite_packages.go
@@ -104,5 +104,5 @@ func contributeLitePackage(descriptor Descriptor, republishImage RepublishImage)
 	j.Steps = append(NewHttpCredentialActions(descriptor.HttpCredentials), j.Steps...)
 	w.Jobs["republish-image"] = j
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }

--- a/octo/octo.go
+++ b/octo/octo.go
@@ -34,6 +34,7 @@ const (
 	PackVersion   = "0.27.0"
 	RichGoVersion = "0.3.10"
 	YJVersion     = "5.0.0"
+	Namespace     = "pb"
 )
 
 var RemovedFiles []string

--- a/octo/offline_packages.go
+++ b/octo/offline_packages.go
@@ -136,5 +136,5 @@ func contributeOfflinePackage(descriptor Descriptor, offlinePackage OfflinePacka
 	j.Steps = append(NewHttpCredentialActions(descriptor.HttpCredentials), j.Steps...)
 	w.Jobs["offline-package"] = j
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }

--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -195,5 +195,5 @@ Bumps %[1]s from ${{ steps.package.outputs.old-version }} to ${{ steps.package.o
 		}
 	}
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }

--- a/octo/test.go
+++ b/octo/test.go
@@ -268,7 +268,7 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 		w.Jobs["create-package"] = j
 	}
 
-	c, err := NewActionContribution(w)
+	c, err := NewActionContributionWithNamespace(Namespace, w)
 	if err != nil {
 		return nil, err
 	}

--- a/octo/test_test.go
+++ b/octo/test_test.go
@@ -17,27 +17,28 @@
 package octo_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/pipeline-builder/octo"
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions"
 	"github.com/sclevine/spec"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 // use our own type as the events cannot be unmarshalled
 type jobs struct {
-	Jobs map[string]*actions.Job `yaml:jobs`
+	Jobs map[string]*actions.Job `yaml:"jobs"`
 }
 
 func testTestGeneration(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		dir string
+		dir        string
 		descriptor octo.Descriptor
 	)
 
@@ -73,7 +74,7 @@ package:
 			contribution, err := octo.ContributeTest(descriptor)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Expect(contribution.Path).To(Equal(".github/workflows/tests.yml"))
+			Expect(contribution.Path).To(Equal(".github/workflows/pb-tests.yml"))
 
 			var workflow jobs
 			Expect(yaml.Unmarshal(contribution.Content, &workflow)).To(Succeed())
@@ -83,20 +84,20 @@ package:
 			Expect(workflow.Jobs["integration"]).To(BeNil())
 
 			steps := workflow.Jobs["unit"].Steps
-			Expect(steps[len(steps) - 1].Run).Should(ContainSubstring("richgo test ./..."))
+			Expect(steps[len(steps)-1].Run).Should(ContainSubstring("richgo test ./..."))
 		})
 
 		context("there are integration tests", func() {
 			it.Before(func() {
 				Expect(os.Mkdir(filepath.Join(dir, "integration"), 0755)).To(Succeed())
-				Expect( ioutil.WriteFile(filepath.Join(dir, "integration", "main.go"), []byte{}, 0644)).To(Succeed())
+				Expect(ioutil.WriteFile(filepath.Join(dir, "integration", "main.go"), []byte{}, 0644)).To(Succeed())
 			})
 
 			it("will contribute a unit test and an integration test pipeline", func() {
 				contribution, err := octo.ContributeTest(descriptor)
 				Expect(err).To(Not(HaveOccurred()))
 
-				Expect(contribution.Path).To(Equal(".github/workflows/tests.yml"))
+				Expect(contribution.Path).To(Equal(".github/workflows/pb-tests.yml"))
 
 				var workflow jobs
 				Expect(yaml.Unmarshal(contribution.Content, &workflow)).To(Succeed())
@@ -106,10 +107,10 @@ package:
 				Expect(workflow.Jobs["integration"]).To(Not(BeNil()))
 
 				unitSteps := workflow.Jobs["unit"].Steps
-				Expect(unitSteps[len(unitSteps) - 1].Run).Should(ContainSubstring("richgo test ./... -run Unit"))
+				Expect(unitSteps[len(unitSteps)-1].Run).Should(ContainSubstring("richgo test ./... -run Unit"))
 
 				integrationSteps := workflow.Jobs["integration"].Steps
-				Expect(integrationSteps[len(integrationSteps) - 1].Run).Should(ContainSubstring("richgo test ./integration/... -run Integration"))
+				Expect(integrationSteps[len(integrationSteps)-1].Run).Should(ContainSubstring("richgo test ./integration/... -run Integration"))
 			})
 		})
 

--- a/octo/update-pipeline.sh
+++ b/octo/update-pipeline.sh
@@ -8,7 +8,7 @@ else
   OLD_VERSION="0.0.0"
 fi
 
-rm .github/workflows/* || true
+rm .github/workflows/pb-*.yml || true
 octo --descriptor "${DESCRIPTOR}"
 
 PAYLOAD=$(gh api /repos/paketo-buildpacks/pipeline-builder/releases/latest)

--- a/octo/update_go.go
+++ b/octo/update_go.go
@@ -81,7 +81,7 @@ Bumps Go from ${{ steps.update-go.outputs.old-go-version }} to ${{ steps.update-
 		},
 	}
 
-	c, err := NewActionContribution(w)
+	c, err := NewActionContributionWithNamespace(Namespace, w)
 	if err != nil {
 		return nil, err
 	}

--- a/octo/update_pipeline.go
+++ b/octo/update_pipeline.go
@@ -81,5 +81,5 @@ Bumps pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipel
 		},
 	}
 
-	return NewActionContribution(w)
+	return NewActionContributionWithNamespace(Namespace, w)
 }


### PR DESCRIPTION
This PR deprecates 'NewActionContribution' in favor of 'NewActionContributionWithNamespace'. You may still use the older method, but it will result in workflows being generated and not having a namespace which is not recommended. When using the new method, all workflows will be generated under the 'pb-*.yml' namespace. This allows the pipeline-builder to also remove old workflows when it updates itself. It will delete everything under 'pb-*.yml' and then regenerate all the files. The namespace also allows you to skip workflows you've custom crafted or generated with other tools, so long as they do not prefix with 'pb-*.yml'.

You may customize the prefix by passing in a namespace string to 'NewActionContributionWithNamespace'. The default used by workflows created by pipeline-builder is 'pb'.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
