### PR TITLE
Fixes "Update Go" job for libcnb

### DIFF
--- a/octo/update_go.go
+++ b/octo/update_go.go
@@ -18,16 +18,23 @@ package octo
 
 import (
 	"fmt"
-	"regexp"
+	"os"
 
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions"
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions/event"
 )
 
 func ContributeUpdateGo(descriptor Descriptor) (*Contribution, error) {
-	goModFiles, err := Find(descriptor.Path, regexp.MustCompile(`go\.(mod|sum)`).MatchString)
+	entries, err := os.ReadDir(descriptor.Path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to Find go.mod or go.sum files in %s\n%w", descriptor.Path, err)
+	}
+
+	goModFiles := []string{}
+	for _, entry := range entries {
+		if entry.Name() == "go.mod" || entry.Name() == "go.sum" {
+			goModFiles = append(goModFiles, entry.Name())
+		}
 	}
 
 	if len(goModFiles) != 2 {


### PR DESCRIPTION
In libcnb, there are multiple sets of go.mod|sum files. One for the top level library and one for the tools. This is a fairly common pattern.

This PR fixes detection so that it only looks at the top level go.mod|sum files. If there are go.mod|sum files in nested directories they are ignore. It is not clear what we should do in the case of go.mod|sum files that are nested. We could potentially generate multiple "Update Go" workflow files or perhaps generate one that updates multiple locations. That will be a feature enhancement request though and not addressed here.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
