### PR TITLE
Pass the OS from the source image to the target

### DIFF
--- a/buildpack/images.go
+++ b/buildpack/images.go
@@ -69,6 +69,22 @@ func Rename(buildpack, tag, newID, newVersion string) (string, error) {
 		return "", fmt.Errorf("unable to unable to parse reference for new buildpack tag\n%w", err)
 	}
 
+	srcCfgFile, err := image.ConfigFile()
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch config file\n%w", err)
+	}
+
+	targetCfgFile, err := newBuildpackage.ConfigFile()
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch config file\n%w", err)
+	}
+	targetCfgFile.OS = srcCfgFile.OS
+
+	newBuildpackage, err = mutate.ConfigFile(newBuildpackage, targetCfgFile)
+	if err != nil {
+		return "", fmt.Errorf("unable to transfer config file\n%w", err)
+	}
+
 	err = remote.Write(reference, newBuildpackage, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return "", fmt.Errorf("unable to write new buildapck\n%w", err)


### PR DESCRIPTION
Presently, images generated with 'update-buildpack-image-id' will have the OS='' (empty string). This is not being copied over from the source image, which has the OS set. This PR changes it so that the value from the source image is set on the target image.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
