### PR TITLE
Allow a version filter for Tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,12 +647,13 @@ with:
 ```
 
 ### Tomcat Dependency
-The Tomcat Dependency watches the [Apache Tomcat Download Page](https://downloads.apache.org/tomcat/tomcat-9/) for new versions.
+The Tomcat Dependency watches the [Apache Tomcat Download Page](https://downloads.apache.org/tomcat/tomcat-9/) for new versions. An optional `version_regex` can be specified to filter on a specific minor versions. If set, the regex must include three capture groups. For example, `^v(10)\.(0)\.([\d]+)/$` to match `10.0.*`.
 
 ```yaml
 uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
 with:
   uri: https://downloads.apache.org/tomcat/tomcat-9
+  version_regex: ^v([\d]+)\.([\d]+)\.([\d]+)/$
 ```
 
 ### Tomee Dependency

--- a/actions/tomcat-dependency/main.go
+++ b/actions/tomcat-dependency/main.go
@@ -34,9 +34,15 @@ func main() {
 		panic(fmt.Errorf("uri must be specified"))
 	}
 
+	versionRegex, ok := inputs["version_regex"]
+	if !ok {
+		fmt.Println(`No version_regex set, using default: ^v([\d]+)\.([\d]+)\.([\d]+)/$`)
+		versionRegex = `^v([\d]+)\.([\d]+)\.([\d]+)/$`
+	}
+
 	c := colly.NewCollector()
 
-	cp := regexp.MustCompile(`^v([\d]+)\.([\d]+)\.([\d]+)/$`)
+	cp := regexp.MustCompile(versionRegex)
 	versions := make(actions.Versions)
 	c.OnHTML("a[href]", func(element *colly.HTMLElement) {
 		if p := cp.FindStringSubmatch(element.Attr("href")); p != nil {


### PR DESCRIPTION
This PR adds a version filter for the Tomcat action. This allows for a more fine grained selection of the version that the dependency will check. By default, it'll look for the latest version of a major branch. For example, `10.*.*`. You can use this to lock the version to the latest of a particular minor branch, like `10.0.*`.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
