### PR TITLE
Add version regex pattern for Maven dependency action

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,11 +572,12 @@ The Maven Dependency queries a [Maven Repository](https://repo1.maven.org/maven2
 ```yaml
 uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
 with:
-  uri:         https://repo1.maven.org/maven2
-  group_id:    org.apache.maven
-  artifact_id: apache-maven
-  classifier:  bin
-  packaging:   tar.gz
+  uri:           https://repo1.maven.org/maven2
+  group_id:      org.apache.maven
+  artifact_id:   apache-maven
+  classifier:    bin
+  packaging:     tar.gz
+  version_regex: ^3\.[\d]+\.[\d]+$
 ```
 
 ### New Relic Dependency


### PR DESCRIPTION
## Summary

This PR adds an `INPUT_VERSION_REGEX` input which can be used to filter the selected version.

It defaults to selecting any three-digit version number. You can set it to `^3\.[\d]+\.[\d]+$` to select only 3.x or `^4\.[\d]+\.[\d]+$` to only select 4.x. The only requirement is that the version regex match the given version string. The first match is the version selected.

## Use Cases

Be able to select multiple versions of a Maven dependency, like for supporting multiple major versions.
