### PR TITLE
Adds an action for fetching rust dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The Pipeline Builder is a collection of tools related to GitHub Actions and othe
     - [Paketo Deps Dependency](#paketo-deps-dependency)
     - [Aternity Dependency](#aternity-dependency)
     - [Rustup Init Dependency](#rustup-init-dependency)
+    - [Rust Dependency](#rust-dependency)
     - [Skywalking Dependency](#skywalking-dependency)
     - [Spring Generations](#spring-generations)
     - [Tomcat Dependency](#tomcat-dependency)
@@ -628,6 +629,16 @@ The Rustup Init Dependency queries the [Rustup Github Project](https://github.co
 uses: docker://ghcr.io/paketo-buildpacks/actions/rustup-init-dependency:main
 with:
   target: x86_64-unknown-linux-musl
+  token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+```
+
+### Rust Dependency
+The Rust Dependency queries the [Rust Github Project](https://github.com/rust-lang/rust) for the latest version. The `target` specifies the target triple to download.
+
+```yaml
+uses: docker://ghcr.io/paketo-buildpacks/actions/rust-dependency:main
+with:
+  target: x86_64-unknown-linux-gnu
   token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 ```
 

--- a/actions/rust-dependency/main.go
+++ b/actions/rust-dependency/main.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/google/go-github/v43/github"
+	"golang.org/x/oauth2"
+
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+const (
+	ORG  = "rust-lang"
+	REPO = "rust"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	target, ok := inputs["target"]
+	if !ok {
+		panic(fmt.Errorf("target must be specified"))
+	}
+
+	var c *http.Client
+	if s, ok := inputs["token"]; ok {
+		c = oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: s}))
+	}
+	gh := github.NewClient(c)
+
+	versions := make(actions.Versions)
+
+	// pull latest version
+	release, _, err := gh.Repositories.GetLatestRelease(context.Background(), ORG, REPO)
+	if err != nil {
+		panic(fmt.Errorf("unable to list existing tags for %s/%s\n%w", ORG, REPO, err))
+	}
+
+	normalVersion, err := actions.NormalizeVersion(*release.TagName)
+	if err != nil {
+		panic(err)
+	}
+
+	versions[normalVersion] = fmt.Sprintf("https://static.rust-lang.org/dist/"+
+		"rust-%s-%s.tar.gz", normalVersion, target)
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write(os.Stdout)
+	}
+}


### PR DESCRIPTION
This adds an action that is similar to rustup-init-dependency. It checks for updates to the Rust dependency. It does this by fetching the most recent release form Github, and then pulling the release version from the main Rust Lang download site.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
