### PR TITLE
Fix Tomee #102

### DIFF
--- a/actions/maven-dependency/main.go
+++ b/actions/maven-dependency/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	versionRegex, ok := inputs["version_regex"]
 	if !ok {
-		fmt.Println(`No version_regex set, using default: ^[\d]+\.[\d]+\.[\d]+/$`)
+		fmt.Println(`No version_regex set, using default: ^[\d]+\.[\d]+\.[\d]+$`)
 		versionRegex = `^[\d]+\.[\d]+\.[\d]+$`
 	}
 	versionPattern := regexp.MustCompile(versionRegex)

--- a/actions/tomee-dependency/main.go
+++ b/actions/tomee-dependency/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/paketo-buildpacks/pipeline-builder/actions"
 )
 
-var TomeeVersionPattern = regexp.MustCompile(`^tomee-?([\d]+)\.?([\d]+)?\.?([\d]+)?[-+.]?(.*)/$`)
+var TomeeVersionPattern = regexp.MustCompile(`^tomee-?([\d]+)\.?([\d]+)?\.?([\d]+)?([-+.])?(.*)/$`)
 
 func main() {
 	inputs := actions.NewInputs()
@@ -52,12 +52,14 @@ func main() {
 	c.OnHTML("a[href]", func(element *colly.HTMLElement) {
 		if p := TomeeVersionPattern.FindStringSubmatch(element.Attr("href")); p != nil {
 			if major == "" || major == p[1] {
-				v := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
+				verKey := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
+				verVal := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
 				if p[4] != "" {
-					v = fmt.Sprintf("%s-%s", v, p[4])
+					verKey = fmt.Sprintf("%s-%s", verKey, p[5])
+					verVal = fmt.Sprintf("%s%s%s", verVal, p[4], p[5])
 				}
 
-				versions[v] = fmt.Sprintf("%s/tomee-%[2]s/apache-tomee-%[2]s-%s.tar.gz", uri, v, dist)
+				versions[verKey] = fmt.Sprintf("%s/tomee-%[2]s/apache-tomee-%[2]s-%s.tar.gz", uri, verVal, dist)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

The new RC versions have a period instead of a dash in the version number. This broke the regular expression and the way download URLs were being generated. This change adjusts the regex and generated download URLs accordingly.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
