### PR TITLE
Add Jitter to "Update Go" action schedule

### DIFF
--- a/octo/jitter/init_test.go
+++ b/octo/jitter/init_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jitter_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnit(t *testing.T) {
+	suite := spec.New("jitter", spec.Report(report.Terminal{}))
+	suite("Tests", testJitter)
+	suite.Run(t)
+}

--- a/octo/jitter/jitter.go
+++ b/octo/jitter/jitter.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jitter
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"math/rand"
+	"strconv"
+
+	"github.com/paketo-buildpacks/pipeline-builder/octo/actions/event"
+)
+
+type Jitterer struct {
+	rng *rand.Rand
+}
+
+// New uses a string to calculate a deterministic seed for an random number generator.
+//
+// The actual implementation does not really matter, we just need to condense a string into an 64-bit number.
+// Also: cryptocraphic security is not important here, we just don't want all cron jobs to run at the same time.
+func New(seedString string) Jitterer {
+	sum := md5.Sum([]byte(seedString))
+	seed := binary.LittleEndian.Uint64(sum[0:8]) ^ binary.BigEndian.Uint64(sum[8:16])
+	return Jitterer{
+		rng: rand.New(rand.NewSource(int64(seed))),
+	}
+}
+
+func (j Jitterer) jitter(min, max int) string {
+	return strconv.Itoa(min + j.rng.Intn(max-min+1))
+}
+
+// Jitter takes a Cron event and adds random values for any properties not set.
+//
+// The values are chosen uniformly-distributed within the validity area of the property.
+// E.g. Minutes will be set to a value between 0 and 59.
+// The exception is the DayOfMonth property.
+// It will never use a value above 28, to ensure it also runs in short months.
+func (j Jitterer) Jitter(cron event.Cron) event.Cron {
+	if cron.Minute == "" {
+		cron.Minute = j.jitter(0, 59)
+	}
+	if cron.Hour == "" {
+		cron.Hour = j.jitter(0, 23)
+	}
+	if cron.DayOfMonth == "" {
+		cron.DayOfMonth = j.jitter(1, 28)
+	}
+	if cron.Month == "" {
+		cron.Month = j.jitter(1, 12)
+	}
+	if cron.DayOfWeek == "" {
+		cron.DayOfWeek = j.jitter(0, 6)
+	}
+	return cron
+}

--- a/octo/jitter/jitter_test.go
+++ b/octo/jitter/jitter_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jitter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/pipeline-builder/octo/actions/event"
+	"github.com/paketo-buildpacks/pipeline-builder/octo/jitter"
+	"github.com/sclevine/spec"
+)
+
+func testJitter(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	context("Jitterer", func() {
+		it("jittering should change unset values", func() {
+			jitterer := jitter.New("my-seed")
+			jittered := jitterer.Jitter(event.Cron{})
+
+			Expect(jittered.DayOfMonth).NotTo(BeEmpty())
+			Expect(jittered.DayOfWeek).NotTo(BeEmpty())
+			Expect(jittered.Hour).NotTo(BeEmpty())
+			Expect(jittered.Minute).NotTo(BeEmpty())
+			Expect(jittered.Month).NotTo(BeEmpty())
+		})
+
+		it("jittering should not change set values", func() {
+			jitterer := jitter.New("my-seed")
+			jittered := jitterer.Jitter(event.Cron{
+				DayOfMonth: "42",
+				DayOfWeek:  "42",
+				Hour:       "42",
+				Minute:     "42",
+				Month:      "42",
+			})
+
+			Expect(jittered.DayOfMonth).To(Equal("42"))
+			Expect(jittered.DayOfWeek).To(Equal("42"))
+			Expect(jittered.Hour).To(Equal("42"))
+			Expect(jittered.Minute).To(Equal("42"))
+			Expect(jittered.Month).To(Equal("42"))
+		})
+
+		it("jittering with the same seed should produce the same result", func() {
+			jitterer := jitter.New("my-seed")
+			jitteredA := jitterer.Jitter(event.Cron{})
+			jitterer = jitter.New("my-seed")
+			jitteredB := jitterer.Jitter(event.Cron{})
+			Expect(jitteredA).To(Equal(jitteredB))
+		})
+
+		it("jittering with different seeds should produce a different result (with high probability)", func() {
+			jitterer := jitter.New("my-seed")
+			jitteredA := jitterer.Jitter(event.Cron{})
+			jitterer = jitter.New("my-other-seed")
+			jitteredB := jitterer.Jitter(event.Cron{})
+			Expect(jitteredA).NotTo(Equal(jitteredB))
+		})
+
+	})
+}

--- a/octo/update_go.go
+++ b/octo/update_go.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions"
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions/event"
+	"github.com/paketo-buildpacks/pipeline-builder/octo/jitter"
 )
 
 func ContributeUpdateGo(descriptor Descriptor) (*Contribution, error) {
@@ -41,10 +42,15 @@ func ContributeUpdateGo(descriptor Descriptor) (*Contribution, error) {
 		return nil, nil
 	}
 
+	seed := fmt.Sprintf("Update Go %s", os.Getenv("GITHUB_REPOSITORY"))
+	cron := jitter.
+		New(seed).
+		Jitter(event.Cron{Hour: "2", DayOfWeek: "1", Month: "*", DayOfMonth: "*"})
+
 	w := actions.Workflow{
 		Name: "Update Go",
 		On: map[event.Type]event.Event{
-			event.ScheduleType:         event.Schedule{{Minute: "0", Hour: "2", DayOfWeek: "1"}},
+			event.ScheduleType:         event.Schedule{cron},
 			event.WorkflowDispatchType: event.WorkflowDispatch{},
 		},
 		Jobs: map[string]actions.Job{


### PR DESCRIPTION
## Summary

Fixes #966 by adding a Jitter to the cron schedule (Alternative 2 in the issue)

The jitter is seeded with the repo name (`GITHUB_REPOSITORY` env) and will there produce a constant value for the same repo (unless renamed).

It is implemented in a separate package to be easily reused in other actions that might profit from this as well.

## Use Cases

Prevent rate limiting

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
