### PR TITLE
Fix two small bugs

### DIFF
--- a/octo/test.go
+++ b/octo/test.go
@@ -258,8 +258,22 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			},
 		}
 
+		skipPrefixes := []string{
+			"paketo-buildpacks",
+			"paketobuildpacks",
+			"paketo-community",
+			"paketocommunity",
+		}
+
 		for _, repo := range descriptor.Package.Repositories {
-			if !strings.Contains(repo, "paketo-buildpacks") && !strings.Contains(repo, "paketobuildpacks") {
+			skipMatch := false
+			for _, skipPrefix := range skipPrefixes {
+				if strings.Contains(repo, skipPrefix) {
+					skipMatch = true
+					break
+				}
+			}
+			if !skipMatch {
 				j.Steps = append(NewDockerCredentialActions(descriptor.DockerCredentials), j.Steps...)
 			}
 		}

--- a/octo/update_go.go
+++ b/octo/update_go.go
@@ -19,6 +19,7 @@ package octo
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions"
 	"github.com/paketo-buildpacks/pipeline-builder/octo/actions/event"
@@ -42,7 +43,20 @@ func ContributeUpdateGo(descriptor Descriptor) (*Contribution, error) {
 		return nil, nil
 	}
 
-	seed := fmt.Sprintf("Update Go %s", os.Getenv("GITHUB_REPOSITORY"))
+	repoName := os.Getenv("GITHUB_REPOSITORY")
+	if len(repoName) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch current working directory\n%w", err)
+		}
+
+		// get the repo name, which should like `paketo-buildpacks/foo`
+		repoName = fmt.Sprintf("%s/%s",
+			filepath.Base(filepath.Dir(filepath.Dir(cwd))),
+			filepath.Base(filepath.Dir(cwd)))
+	}
+
+	seed := fmt.Sprintf("Update Go %s", repoName)
 	cron := jitter.
 		New(seed).
 		Jitter(event.Cron{Hour: "2", DayOfWeek: "1", Month: "*", DayOfMonth: "*"})


### PR DESCRIPTION
First. This fixes the case where running in a paketo-community repo. It prevents the Docker credentials from being added to the test workflow multiple times.

Second. This fixes an issue where you try to run `octo` outside of Github Actions, like on your local machine. In this case, `$GITHUB_REPOSITORY` probably will not be set and so the seed string for the cron jitter will be just `Update Go ` which is static and always returns the same number. This will unnecessarily change the cron value used in the `Update Go` job. This change will fallback to looking at the directory paths to try and find the right name to use. It assumes the folder structure is `paketo-buildpacks/<some-buildpack>` like the way repos are structured on Github. This will not be perfect, but it a bit better.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
