### PR TITLE
Close #996: Bump to Go 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,14 @@ The YourKit Dependency watches the [YourKit Download Page](https://www.yourkit.c
 uses: docker://ghcr.io/paketo-buildpacks/actions/yourkit-dependency:main
 ```
 
+## Updating Go version
+
+Dependabot could suggest to bump the Go version in some places, but you should make sure that the Go version is the same across the different tools in this repository.
+
+Most importantly, the Go version must be bumped in [Octo](octo/octo.go#L33) and in the [actions Dockerfile](actions/Dockerfile#L1) at the same time.
+
+Also, it could be a good idea to sync the go version in [the different workflows](.github/workflows).
+
 ## License
 This library is released under version 2.0 of the [Apache License][a].
 

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ When it is time to update the Go version in the project, you should make sure th
 
 Most importantly, the Go version must be bumped in [Octo](octo/octo.go#L33) and in the [actions Dockerfile](actions/Dockerfile#L1) at the same time.
 
-Also, it could be a good idea to sync the go version in [the different workflows](.github/workflows).
+The Go version is also in [the different workflows](.github/workflows), however, this will be updated automatically by `octo`. You can run `octo` locally or submit a PR, and when the PR is merged CI will run `octo` and in turn submit another PR that updates the Go version.
 
 ## License
 This library is released under version 2.0 of the [Apache License][a].

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ uses: docker://ghcr.io/paketo-buildpacks/actions/yourkit-dependency:main
 
 ## Updating Go version
 
-Dependabot could suggest to bump the Go version in some places, but you should make sure that the Go version is the same across the different tools in this repository.
+When it is time to update the Go version in the project, you should make sure that the Go version is the same across the different tools in this repository.
 
 Most importantly, the Go version must be bumped in [Octo](octo/octo.go#L33) and in the [actions Dockerfile](actions/Dockerfile#L1) at the same time.
 

--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build-stage
+FROM golang:1.18 as build-stage
 
 RUN apt-get update && apt-get install -y --no-install-recommends upx
 


### PR DESCRIPTION
## Summary
* to allow actions requiring Go 1.18 to continue building




## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
