### PR TITLE
Update pb-create-action-liberty-dependency.yml

### DIFF
--- a/.github/workflows/pb-create-action-liberty-dependency.yml
+++ b/.github/workflows/pb-create-action-liberty-dependency.yml
@@ -13,6 +13,7 @@ name: Create Action liberty-dependency
     release:
         types:
             - published
+    merge_group:     
 jobs:
     create-action:
         name: Create Action


### PR DESCRIPTION
Enable GH merge group

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Enabling github merge groups to help with dep PRs.  

## Use Cases
<!-- An explanation of the use cases your change enables -->
Each new release of liberty results in 15 PRs being created for the dependency.  It's a real pain to rebase and merge each PR.  Using github merge queues eliminates the manual effort of merging and rebasing the PRs.  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
