### PR TITLE
Tell dependabot to ignore gomega

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
       directory: /
       schedule:
         interval: daily
+      ignore:
+        - dependency-name: github.com/onsi/gomega
       labels:
         - semver:patch
         - type:dependency-upgrade

--- a/octo/dependabot.go
+++ b/octo/dependabot.go
@@ -39,6 +39,9 @@ func ContributeDependabot(descriptor Descriptor) (*Contribution, error) {
 				Directory:        "/",
 				Schedule:         dependabot.Schedule{Interval: dependabot.DailyInterval},
 				Labels:           []string{"semver:patch", "type:dependency-upgrade"},
+				Ignore: []dependabot.Dependency{
+					{Name: "github.com/onsi/gomega"},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Gomega releases often, and it creates a lot of churn. It is also a dev dependency, so we can just update it weekly when we update dependencies.

## Use Cases

Less churn.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
