### PR TITLE
Closes #1053: Upgrade setup-go from v3 to v4

### DIFF
--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -16,7 +16,7 @@ jobs:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                 path: ${{ env.HOME }}/go/pkg/mod
                 restore-keys: ${{ runner.os }}-go-
-            - uses: actions/setup-go@v3
+            - uses: actions/setup-go@v4
               with:
                 go-version: "1.18"
             - name: Install create-package
@@ -95,7 +95,7 @@ jobs:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                 path: ${{ env.HOME }}/go/pkg/mod
                 restore-keys: ${{ runner.os }}-go-
-            - uses: actions/setup-go@v3
+            - uses: actions/setup-go@v4
               with:
                 go-version: "1.18"
             - name: Install richgo

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v3
+            - uses: actions/setup-go@v4
               with:
                 go-version: "1.18"
             - uses: actions/checkout@v3

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v3
+            - uses: actions/setup-go@v4
               with:
                 go-version: "1.18"
             - name: Install octo

--- a/octo/builder_dependencies.go
+++ b/octo/builder_dependencies.go
@@ -18,7 +18,6 @@ package octo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,7 +31,7 @@ import (
 
 func ContributeBuilderDependencies(descriptor Descriptor) ([]Contribution, error) {
 	file := filepath.Join(descriptor.Path, "builder.toml")
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
@@ -87,7 +86,7 @@ func contributeBuildImage(descriptor Descriptor, image string, classifier string
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{
@@ -157,7 +156,7 @@ func contributeLifecycle(descriptor Descriptor) (Contribution, error) {
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{

--- a/octo/buildpack_dependencies.go
+++ b/octo/buildpack_dependencies.go
@@ -41,7 +41,7 @@ func ContributeBuildpackDependencies(descriptor Descriptor) ([]Contribution, err
 					RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 					Steps: []actions.Step{
 						{
-							Uses: "actions/setup-go@v3",
+							Uses: "actions/setup-go@v4",
 							With: map[string]interface{}{"go-version": GoVersion},
 						},
 						{

--- a/octo/create_builder.go
+++ b/octo/create_builder.go
@@ -41,7 +41,7 @@ func ContributeCreateBuilder(descriptor Descriptor) (*Contribution, error) {
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{

--- a/octo/create_package.go
+++ b/octo/create_package.go
@@ -18,7 +18,7 @@ package octo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -44,7 +44,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 	}
 
 	file := filepath.Join(descriptor.Path, "buildpack.toml")
-	s, err := ioutil.ReadFile(file)
+	s, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read %s\n%w", file, err)
 	}
@@ -69,7 +69,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{

--- a/octo/lite_packages.go
+++ b/octo/lite_packages.go
@@ -73,7 +73,7 @@ func contributeLitePackage(descriptor Descriptor, republishImage RepublishImage)
 						},
 					},
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						If:   "${{ ! steps.version.outputs.skip }}",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},

--- a/octo/offline_packages.go
+++ b/octo/offline_packages.go
@@ -74,7 +74,7 @@ func contributeOfflinePackage(descriptor Descriptor, offlinePackage OfflinePacka
 						},
 					},
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						If:   "${{ ! steps.version.outputs.skip }}",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},

--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -18,7 +18,6 @@ package octo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -35,7 +34,7 @@ func ContributePackageDependencies(descriptor Descriptor) ([]Contribution, error
 	var contributions []Contribution
 
 	file := filepath.Join(descriptor.Path, "package.toml")
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
@@ -47,7 +46,7 @@ func ContributePackageDependencies(descriptor Descriptor) ([]Contribution, error
 	}
 
 	file = filepath.Join(descriptor.Path, "buildpack.toml")
-	b, err = ioutil.ReadFile(file)
+	b, err = os.ReadFile(file)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
@@ -75,16 +74,17 @@ func ContributePackageDependencies(descriptor Descriptor) ([]Contribution, error
 }
 
 // findIds will return the pkg group id (used in package.toml) and the buildpack id (used in buildpack.toml)
-//   it will do some fuzzy matching because there is not a strict relationship between the two
-//     - often pkg group id is `repo.io/buildpack/id:version`, so you can extract `buildpack/id`
-//     - if that does not exist as a build pack id, then we search for just the last part of
-//         buildpack id and a matching version
 //
-//         for example, `gcr.io/tanzu-buildpacks/bellsoft-liberica:1.2.3`, we'll look for `bellsoft-liberica`
-//            and version `1.2.3` in buildpack.toml
+//	  it will do some fuzzy matching because there is not a strict relationship between the two
+//	    - often pkg group id is `repo.io/buildpack/id:version`, so you can extract `buildpack/id`
+//	    - if that does not exist as a build pack id, then we search for just the last part of
+//	        buildpack id and a matching version
 //
-//            if there is a match, then we return the found buildpack id, let's say it finds `paketo-buildpacks/bellsoft-liberica`
-//			  then we return `gcr.io/paketo-buildpacks/bellsoft-liberica:1.2.3`
+//	        for example, `gcr.io/tanzu-buildpacks/bellsoft-liberica:1.2.3`, we'll look for `bellsoft-liberica`
+//	           and version `1.2.3` in buildpack.toml
+//
+//	           if there is a match, then we return the found buildpack id, let's say it finds `paketo-buildpacks/bellsoft-liberica`
+//				  then we return `gcr.io/paketo-buildpacks/bellsoft-liberica:1.2.3`
 func findIds(bpOrders _package.BuildpackOrderGroups, dep _package.Dependency) (string, string, error) {
 	re := regexp.MustCompile(`^(?:.+://)?(.+?)/(.+):([^:]+)$`)
 	if g := re.FindStringSubmatch(dep.URI); g == nil {
@@ -135,7 +135,7 @@ func contributePackageDependency(descriptor Descriptor, name string, bpId string
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{

--- a/octo/test.go
+++ b/octo/test.go
@@ -82,7 +82,7 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 					},
 				},
 				{
-					Uses: "actions/setup-go@v3",
+					Uses: "actions/setup-go@v4",
 					With: map[string]interface{}{"go-version": GoVersion},
 				},
 			},
@@ -123,7 +123,7 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 					},
 				},
 				{
-					Uses: "actions/setup-go@v3",
+					Uses: "actions/setup-go@v4",
 					With: map[string]interface{}{"go-version": GoVersion},
 				},
 				{
@@ -201,7 +201,7 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 			Steps: []actions.Step{
 				{
-					Uses: "actions/setup-go@v3",
+					Uses: "actions/setup-go@v4",
 					With: map[string]interface{}{"go-version": GoVersion},
 				},
 				{

--- a/octo/update_go.go
+++ b/octo/update_go.go
@@ -73,7 +73,7 @@ func ContributeUpdateGo(descriptor Descriptor) (*Contribution, error) {
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{

--- a/octo/update_pipeline.go
+++ b/octo/update_pipeline.go
@@ -41,7 +41,7 @@ func ContributeUpdatePipeline(descriptor Descriptor) (Contribution, error) {
 				RunsOn: []actions.VirtualEnvironment{actions.UbuntuLatest},
 				Steps: []actions.Step{
 					{
-						Uses: "actions/setup-go@v3",
+						Uses: "actions/setup-go@v4",
 						With: map[string]interface{}{"go-version": GoVersion},
 					},
 					{


### PR DESCRIPTION
## Summary
Upgrade setup-go from v3 to v4

## Use Cases

* using find and replace across the projects files
* only non-breaking changes were added
  * cache by default (warning if broken),
  * bugfix version bump for json5 dependency
  * go bin added to path when not specifying a Go version and relying on runner provided Go (does not concern us since we always specified a go version)
  * warning added when not specifying a Go version

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
