### PR TITLE
Add support for merge queues

### DIFF
--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -1,5 +1,10 @@
 name: Tests
 "on":
+    merge_group:
+        types:
+            - checks_requested
+        branches:
+            - main
     pull_request: {}
     push:
         branches:

--- a/octo/actions/event/merge_group.go
+++ b/octo/actions/event/merge_group.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package event
+
+const MergeGroupType Type = "merge_group"
+
+type MergeGroupActivityType string
+
+const (
+	MergeGroupChecksRequested MergeGroupActivityType = "checks_requested"
+)
+
+type MergeGroup struct {
+	Types          []MergeGroupActivityType `yaml:",omitempty"`
+	Branches       []string                 `yaml:",omitempty"`
+	BranchesIgnore []string                 `yaml:"branches-ignore,omitempty"`
+	Paths          []string                 `yaml:",omitempty"`
+	PathsIgnore    []string                 `yaml:"paths-ignore,omitempty"`
+}
+
+func (MergeGroup) Type() Type {
+	return MergeGroupType
+}

--- a/octo/test.go
+++ b/octo/test.go
@@ -51,6 +51,10 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 			event.PushType: event.Push{
 				Branches: []string{"main"},
 			},
+			event.MergeGroupType: event.MergeGroup{
+				Types:    []event.MergeGroupActivityType{event.MergeGroupChecksRequested},
+				Branches: []string{"main"},
+			},
 		},
 		Jobs: map[string]actions.Job{},
 	}


### PR DESCRIPTION
## Summary

This PR adds a merge group event type which can be added to workflows as a trigger. It exposes the documented types, of which there is only one, and it adds filters for branch and path (these are not documented, but I see references to them in other projects and they are needed to make this useful). It also updates the tests workflow so that tests are run when a merge group event is detected. It does not add label checks or action workflows. Those will run on PR, which is probably sufficient. We just want to re-run the tests in the merge queue to validate.

This PR has not been tested because we cannot use the merge queue feature yet. EasyCLA is not compatible. This is an attempt to prepare but a follow up PR may be required. Consider this experimental for now.

Resolves #1036
