### PR TITLE
Add support for Package ID ending with -offline

### DIFF
--- a/octo/descriptor.go
+++ b/octo/descriptor.go
@@ -39,6 +39,7 @@ type Descriptor struct {
 	Actions           []Action
 	Dependencies      []Dependency
 	Test              Test
+	PackageMatcher    string
 }
 
 type GitHub struct {

--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -105,10 +105,9 @@ func findIds(bpOrders _package.BuildpackOrderGroups, dep _package.Dependency, de
 		}
 
 		// search for a fuzzy match
+		endOfId := strings.Split(possibleBpId, "/")[1]
 		for _, order := range bpOrders.Orders {
 			for _, group := range order.Groups {
-				endOfId := strings.Split(possibleBpId, "/")[1]
-				// fmt.Println("group.Id", group.ID, "endOfId", endOfId, "group.Version", group.Version, "version", version)
 				if strings.HasSuffix(group.ID, endOfId) && group.Version == version {
 					pkgId := fmt.Sprintf("%s/%s", registry, possibleBpId)
 					bpId := fmt.Sprintf("%s/%s", registry, group.ID)
@@ -118,16 +117,16 @@ func findIds(bpOrders _package.BuildpackOrderGroups, dep _package.Dependency, de
 			}
 		}
 
-		// search for a regex match
-		for _, order := range bpOrders.Orders {
-			for _, group := range order.Groups {
-				endOfId := strings.Split(possibleBpId, "/")[1]
-				re := regexp.MustCompile(descriptor.PackageMatcher)
-				if g := re.FindStringSubmatch(endOfId); g != nil && group.Version == version {
-					pkgId := fmt.Sprintf("%s/%s", registry, possibleBpId)
-					bpId := fmt.Sprintf("%s/%s", registry, group.ID)
-					// fmt.Println("pkgId", pkgId, "bpId", bpId)
-					return pkgId, bpId, nil
+		// search for a regex match if set
+		if descriptor.PackageMatcher != "" {
+			re := regexp.MustCompile(descriptor.PackageMatcher)
+			for _, order := range bpOrders.Orders {
+				for _, group := range order.Groups {
+					if g := re.FindStringSubmatch(endOfId); g != nil && group.Version == version {
+						pkgId := fmt.Sprintf("%s/%s", registry, possibleBpId)
+						bpId := fmt.Sprintf("%s/%s", registry, group.ID)
+						return pkgId, bpId, nil
+					}
 				}
 			}
 		}

--- a/octo/package_dependencies_test.go
+++ b/octo/package_dependencies_test.go
@@ -1,0 +1,196 @@
+package octo
+
+import (
+	"github.com/buildpacks/libcnb"
+	_package "github.com/paketo-buildpacks/pipeline-builder/octo/package"
+	"testing"
+)
+
+func TestFindIds(t *testing.T) {
+	type args struct {
+		bpOrders   _package.BuildpackOrderGroups
+		dep        _package.Dependency
+		descriptor Descriptor
+	}
+
+	var tests = []struct {
+		name        string
+		args        args
+		packageId   string
+		buildpackId string
+		wantErr     bool
+	}{
+		{
+			name: "GroupId ends with buildpackId",
+			args: struct {
+				bpOrders   _package.BuildpackOrderGroups
+				dep        _package.Dependency
+				descriptor Descriptor
+			}{
+				bpOrders: _package.BuildpackOrderGroups{
+					Orders: []libcnb.BuildpackOrder{
+						{
+							Groups: []libcnb.BuildpackOrderBuildpack{
+								{
+									ID:       "paketo-buildpacks/bellsoft-liberica",
+									Version:  "9.12.0",
+									Optional: false,
+								},
+							},
+						},
+					},
+				},
+				dep: struct {
+					URI string
+				}{
+					URI: "docker://gcr.io/tanzu-buildpacks/bellsoft-liberica:9.12.0",
+				},
+				descriptor: Descriptor{},
+			},
+			packageId:   "gcr.io/tanzu-buildpacks/bellsoft-liberica",
+			buildpackId: "gcr.io/paketo-buildpacks/bellsoft-liberica",
+			wantErr:     false,
+		},
+		{
+			name: "PackageId ends with -offline",
+			args: struct {
+				bpOrders   _package.BuildpackOrderGroups
+				dep        _package.Dependency
+				descriptor Descriptor
+			}{
+				bpOrders: _package.BuildpackOrderGroups{
+					Orders: []libcnb.BuildpackOrder{
+						{
+							Groups: []libcnb.BuildpackOrderBuildpack{
+								{
+									ID:       "tanzu-buildpacks/tanzu-bellsoft-liberica",
+									Version:  "9.12.0",
+									Optional: false,
+								},
+							},
+						},
+					},
+				},
+				dep: struct {
+					URI string
+				}{
+					URI: "docker://gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica-offline:9.12.0",
+				},
+				descriptor: Descriptor{},
+			},
+			packageId:   "gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica-offline",
+			buildpackId: "gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica",
+			wantErr:     false,
+		},
+		{
+			name: "Unable to match coordinates",
+			args: struct {
+				bpOrders   _package.BuildpackOrderGroups
+				dep        _package.Dependency
+				descriptor Descriptor
+			}{
+				bpOrders: _package.BuildpackOrderGroups{
+					Orders: []libcnb.BuildpackOrder{
+						{
+							Groups: []libcnb.BuildpackOrderBuildpack{
+								{
+									ID:       "tanzu-buildpacks/tanzu-bellsoft-liberica",
+									Version:  "9.12.0",
+									Optional: false,
+								},
+							},
+						},
+					},
+				},
+				dep: struct {
+					URI string
+				}{
+					URI: "docker://gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica-HELLO:9.12.0",
+				},
+				descriptor: Descriptor{
+					PackageMatcher: "-offline",
+				},
+			},
+			packageId:   "",
+			buildpackId: "",
+			wantErr:     true,
+		},
+		{
+			name: "PackageId is a perfect match",
+			args: struct {
+				bpOrders   _package.BuildpackOrderGroups
+				dep        _package.Dependency
+				descriptor Descriptor
+			}{
+				bpOrders: _package.BuildpackOrderGroups{
+					Orders: []libcnb.BuildpackOrder{
+						{
+							Groups: []libcnb.BuildpackOrderBuildpack{
+								{
+									ID:       "tanzu-buildpacks/deprecation-warnings",
+									Version:  "0.0.3",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+				dep: struct {
+					URI string
+				}{
+					URI: "docker://gcr.io/tanzu-buildpacks/deprecation-warnings:0.0.3",
+				},
+				descriptor: Descriptor{},
+			},
+			packageId:   "gcr.io/tanzu-buildpacks/deprecation-warnings",
+			buildpackId: "gcr.io/tanzu-buildpacks/deprecation-warnings",
+			wantErr:     false,
+		},
+		{
+			name: "Dep URI is not valid",
+			args: struct {
+				bpOrders   _package.BuildpackOrderGroups
+				dep        _package.Dependency
+				descriptor Descriptor
+			}{
+				bpOrders: _package.BuildpackOrderGroups{
+					Orders: []libcnb.BuildpackOrder{
+						{
+							Groups: []libcnb.BuildpackOrderBuildpack{
+								{
+									ID:       "tanzu-buildpacks/deprecation-warnings",
+									Version:  "0.0.3",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+				dep: struct {
+					URI string
+				}{
+					URI: "hello all!",
+				},
+				descriptor: Descriptor{},
+			},
+			packageId:   "",
+			buildpackId: "",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := findIds(tt.args.bpOrders, tt.args.dep, tt.args.descriptor)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findIds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.packageId {
+				t.Errorf("findIds() got = %v, packageId %v", got, tt.packageId)
+			}
+			if got1 != tt.buildpackId {
+				t.Errorf("findIds() got1 = %v, packageId %v", got1, tt.buildpackId)
+			}
+		})
+	}
+}

--- a/octo/package_dependencies_test.go
+++ b/octo/package_dependencies_test.go
@@ -76,7 +76,9 @@ func TestFindIds(t *testing.T) {
 				}{
 					URI: "docker://gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica-offline:9.12.0",
 				},
-				descriptor: Descriptor{},
+				descriptor: Descriptor{
+					PackageMatcher: "*-offline",
+				},
 			},
 			packageId:   "gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica-offline",
 			buildpackId: "gcr.io/tanzu-buildpacks/tanzu-bellsoft-liberica",


### PR DESCRIPTION
* Needed to support Tanzu buildpacks that can not have buildpack id and package id the same

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
