### PR TITLE
Switch to using Azul Metadata API

### DIFF
--- a/actions/azul-zulu-dependency/main.go
+++ b/actions/azul-zulu-dependency/main.go
@@ -37,15 +37,6 @@ func main() {
 		panic(fmt.Errorf("version must be specified"))
 	}
 
-	// uri := fmt.Sprintf("https://api.azul.com/zulu/download/community/v1.0/bundles/latest/"+
-	// 	"?arch=x86"+
-	// 	"&ext=tar.gz"+
-	// 	"&features=%s"+
-	// 	"&hw_bitness=64"+
-	// 	"&jdk_version=%s"+
-	// 	"&os=linux"+
-	// 	"&javafx=false",
-	// 	t, v)
 	uri := fmt.Sprintf("https://api.azul.com/metadata/v1/zulu/packages/?"+
 		"os=linux-glibc&"+
 		"arch=x64&"+


### PR DESCRIPTION
## Summary

This commit switches the updater action from the old Discovery API to using the Metadata API.

## Use Cases

Resolve https://github.com/paketo-buildpacks/azul-zulu/issues/322

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
