### PR TITLE
Add dotnet new-relic agent support

### DIFF
--- a/actions/new-relic-dependency/main.go
+++ b/actions/new-relic-dependency/main.go
@@ -52,6 +52,20 @@ func main() {
 					h, p[1], p[2], p[3], p[4])
 			}
 		})
+	case "dotnet":
+		uri = "https://download.newrelic.com/dot_net_agent/latest_release/"
+
+		cp := regexp.MustCompile(`^/dot_net_agent/latest_release/newrelic-dotnet-agent_([\d]+)\.([\d]+)\.([\d]+)_amd64.tar.gz$`)
+		c.OnHTML("a[href]", func(element *colly.HTMLElement) {
+			h := element.Attr("href")
+			if p := cp.FindStringSubmatch(h); p != nil {
+				v := fmt.Sprintf("%s.%s.%s", p[1], p[2], p[3])
+
+				versions[v] = fmt.Sprintf(
+					"https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_%s.%s.%s_amd64.tar.gz",
+					 p[1], p[2], p[3])
+			}
+		})
 	default:
 		panic(fmt.Errorf("unsupported type %s", t))
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Updates the new-relic action to support a new 'type' for the dotnet agent. This agent is hosted in a different way then the php agent and so the URI and regex is different: https://download.newrelic.com/dot_net_agent/

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
