### PR TITLE
Creates an Oracle dependency updater

### DIFF
--- a/actions/oracle-dependency/main.go
+++ b/actions/oracle-dependency/main.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/gocolly/colly"
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
+)
+
+func main() {
+	inputs := actions.NewInputs()
+
+	typeName, ok := inputs["type"]
+	if !ok {
+		panic(fmt.Errorf("type must be specified"))
+	}
+
+	versionBranch, ok := inputs["version"]
+	if !ok {
+		panic(fmt.Errorf("version must be specified"))
+	}
+
+	var pattern *regexp.Regexp
+	var key string
+	var urlTemplate string
+	switch typeName {
+	case "jdk":
+		pattern = regexp.MustCompile(`^JDK Development Kit (\d+\.\d+\.\d+) downloads$`)
+		key = fmt.Sprintf("java%s", versionBranch)
+		urlTemplate = "https://download.oracle.com/java/%s/archive/jdk-%s_linux-x64_bin.tar.gz"
+	case "graalvm":
+		pattern = regexp.MustCompile(`^GraalVM for JDK (\d+\.\d+\.\d+) downloads$`)
+		key = fmt.Sprintf("graalvmjava%s", versionBranch)
+		urlTemplate = "https://download.oracle.com/graalvm/%s/archive/graalvm-jdk-%s_linux-x64_bin.tar.gz"
+	default:
+		panic(fmt.Errorf("unsupported type %s", typeName))
+	}
+
+	uri := "https://www.oracle.com/java/technologies/downloads"
+
+	c := colly.NewCollector()
+	versions := make(actions.Versions)
+
+	c.OnHTML(fmt.Sprintf("h3[id=%s]", key), func(element *colly.HTMLElement) {
+		foundVersions := pattern.FindStringSubmatch(element.Text)
+		if len(foundVersions) == 2 {
+			foundVersion := foundVersions[1] // there should only ever be one
+			versions[foundVersion] = fmt.Sprintf(urlTemplate, versionBranch, foundVersion)
+		}
+	})
+
+	if err := c.Visit(uri); err != nil {
+		panic(err)
+	}
+
+	if o, err := versions.GetLatest(inputs); err != nil {
+		panic(err)
+	} else {
+		o.Write()
+	}
+}


### PR DESCRIPTION
## Summary

This PR creates an Oracle dependency updater. It looks at `https://www.oracle.com/java/technologies/downloads/` and scrapes out the latest version numbers for the given type and version branch. Valid types are either `jdk` or `graalvm`. It will then fetch the download and calculate all the metadata.

## Use Cases

This works for downloading Oracle dependencies. Currently, we're using Foojay for Oracle JDK updates, but I couldn't quickly figure out how to get it to pull down GraalVM updates. I did this instead and the bonus is we're getting updates as soon as they are published by Oracle.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
