### PR TITLE
Issue #111: Bellsoft Liberica actions adds source

### DIFF
--- a/actions/bellsoft-liberica-dependency/main.go
+++ b/actions/bellsoft-liberica-dependency/main.go
@@ -43,26 +43,41 @@ func main() {
 	if !ok {
 		panic(fmt.Errorf("product must be specified"))
 	}
+	if p != "liberica" && p != "nik" {
+		panic(fmt.Errorf("product must either be liberica or nik"))
+	}
 
-	uri := fmt.Sprintf("https://api.bell-sw.com/v1/%s/releases"+
-		"?arch=x86"+
-		"&bitness=64"+
-		"&bundle-type=%s"+
-		"&os=linux"+
-		"&package-type=tar.gz"+
-		"&version-feature=%s"+
-		"&version-modifier=latest",
-		p, t, v)
-	if p == "nik" {
+	commonStaticParams := "&version-modifier=latest"
+	uriStaticParams := "?arch=x86" +
+		"&bitness=64" +
+		"&os=linux" +
+		"&package-type=tar.gz" +
+		commonStaticParams
+	sourceUriStaticParams := "?package-type=src.tar.gz" +
+		commonStaticParams
+
+	uri := ""
+	sourceUri := ""
+	if p == "liberica" {
 		uri = fmt.Sprintf("https://api.bell-sw.com/v1/%s/releases"+
-			"?arch=x86"+
-			"&bitness=64"+
+			uriStaticParams+
 			"&bundle-type=%s"+
-			"&os=linux"+
-			"&package-type=tar.gz"+
-			"&component-version=liberica%%40%s"+
-			"&version-modifier=latest",
+			"&version-feature=%s",
 			p, t, v)
+		sourceUri = fmt.Sprintf("https://api.bell-sw.com/v1/%s/releases"+
+			sourceUriStaticParams+
+			"&version-feature=%s",
+			p, v)
+	} else if p == "nik" {
+		uri = fmt.Sprintf("https://api.bell-sw.com/v1/%s/releases"+
+			uriStaticParams+
+			"&bundle-type=%s"+
+			"&component-version=liberica%%40%s",
+			p, t, v)
+		sourceUri = fmt.Sprintf("https://api.bell-sw.com/v1/%s/releases"+
+			sourceUriStaticParams+
+			"&component-version=liberica%%40%s",
+			p, v)
 	}
 
 	resp, err := http.Get(uri)
@@ -86,21 +101,7 @@ func main() {
 	for _, r := range raw {
 		key := fmt.Sprintf("%d.%d.%d-%d", r.FeatureVersion, r.InterimVersion, r.UpdateVersion, r.BuildVersion)
 		if p == "nik" {
-			if v := actions.ExtendedVersionPattern.FindStringSubmatch(r.Components[0].Version); v != nil {
-				s := fmt.Sprintf("%s.%s.%s", v[1], v[2], v[3])
-				if v[4] != "" {
-					s = fmt.Sprintf("%s-%s", s, v[4])
-				}
-				key = s
-
-				// Use NIK version for CPE/PURL
-				re := regexp.MustCompile(`\/vm/([\d]+\.[\d]+\.[\d]+\.?[\d]?)\/`)
-				matches := re.FindStringSubmatch(r.DownloadURL)
-				if matches == nil || len(matches) != 2 {
-					panic(fmt.Errorf("unable to parse NIK version: %s", matches))
-				}
-				additionalOutputs["purl"] = matches[1]
-			}
+			key = determineNikVersion(r, additionalOutputs)
 		}
 		versions[key] = r.DownloadURL
 	}
@@ -108,6 +109,34 @@ func main() {
 	latestVersion, err := versions.GetLatestVersion(inputs)
 	if err != nil {
 		panic(fmt.Errorf("unable to get latest version\n%w", err))
+	}
+
+	sourceResp, err := http.Get(sourceUri)
+	if err != nil {
+		panic(fmt.Errorf("unable to get %s\n%w", uri, err))
+	}
+	defer sourceResp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		panic(fmt.Errorf("unable to download %s: %d", uri, resp.StatusCode))
+	}
+
+	var sourceRaw []Release
+	if err := json.NewDecoder(sourceResp.Body).Decode(&sourceRaw); err != nil {
+		panic(fmt.Errorf("unable to decode payload\n%w", err))
+	}
+
+	sources := make(map[string]string)
+	for _, r := range sourceRaw {
+		key := fmt.Sprintf("%d.%d.%d-%d", r.FeatureVersion, r.InterimVersion, r.UpdateVersion, r.BuildVersion)
+		if p == "nik" {
+			key = determineNikVersion(r, additionalOutputs)
+		}
+		sources[key] = r.DownloadURL
+	}
+
+	if sources != nil {
+		additionalOutputs["source"] = sources[latestVersion.Original()]
 	}
 
 	outputs, err := actions.NewOutputs(versions[latestVersion.Original()], latestVersion, additionalOutputs)
@@ -124,6 +153,26 @@ func main() {
 	}
 
 	outputs.Write()
+}
+
+func determineNikVersion(r Release, additionalOutputs actions.Outputs) string {
+	key := ""
+	if v := actions.ExtendedVersionPattern.FindStringSubmatch(r.Components[0].Version); v != nil {
+		s := fmt.Sprintf("%s.%s.%s", v[1], v[2], v[3])
+		if v[4] != "" {
+			s = fmt.Sprintf("%s-%s", s, v[4])
+		}
+		key = s
+
+		// Use NIK version for CPE/PURL
+		re := regexp.MustCompile(`\/vm/([\d]+\.[\d]+\.[\d]+\.?[\d]?)\/`)
+		matches := re.FindStringSubmatch(r.DownloadURL)
+		if matches == nil || len(matches) != 2 {
+			panic(fmt.Errorf("unable to parse NIK version: %s", matches))
+		}
+		additionalOutputs["purl"] = matches[1]
+	}
+	return key
 }
 
 type Release struct {


### PR DESCRIPTION
## Summary


With:
`INPUT_PRODUCT=nik;INPUT_TYPE=core;INPUT_VERSION=17`

```
sha256<<9bb9b6f2edb017321068e76afdbd1dbd
44c5e9c4488957613fbebce189b58d867ab27c132cd5b723e79efc78674d7724
9bb9b6f2edb017321068e76afdbd1dbd
uri<<9bb9b6f2edb017321068e76afdbd1dbd
https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-core-openjdk17.0.8.1+1-23.0.1+2-linux-amd64.tar.gz
9bb9b6f2edb017321068e76afdbd1dbd
version<<9bb9b6f2edb017321068e76afdbd1dbd
17.0.8
9bb9b6f2edb017321068e76afdbd1dbd
purl<<9bb9b6f2edb017321068e76afdbd1dbd
23.0.1
9bb9b6f2edb017321068e76afdbd1dbd
source_sha256<<9bb9b6f2edb017321068e76afdbd1dbd
0f9baae8f965ffe0dc01b66df848be35893568a51536dc5298fd3c4e61d46efa
9bb9b6f2edb017321068e76afdbd1dbd
source<<9bb9b6f2edb017321068e76afdbd1dbd
https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk17.0.8.1+1-23.0.1+2-src.tar.gz
9bb9b6f2edb017321068e76afdbd1dbd
```

With:
`INPUT_PRODUCT=liberica;INPUT_TYPE=jdk;INPUT_VERSION=17`

```
sha256<<fda167961024fe5d7af4ba4652393c38
8b2a27a576d0c8afc4d41f8e836c60ff4c04bbf747fc491d240975396d4e8cb8
fda167961024fe5d7af4ba4652393c38
uri<<fda167961024fe5d7af4ba4652393c38
https://github.com/bell-sw/Liberica/releases/download/17.0.8.1+1/bellsoft-jdk17.0.8.1+1-linux-amd64.tar.gz
fda167961024fe5d7af4ba4652393c38
version<<fda167961024fe5d7af4ba4652393c38
17.0.8
fda167961024fe5d7af4ba4652393c38
source_sha256<<fda167961024fe5d7af4ba4652393c38
524da450f68c84a1fbf93c14f5a6df01cdd744a620cbf92be8827bc87d0b6825
fda167961024fe5d7af4ba4652393c38
source<<fda167961024fe5d7af4ba4652393c38
https://github.com/bell-sw/Liberica/releases/download/17.0.8.1+1/bellsoft-jdk17.0.8.1+1-src-full.tar.gz
fda167961024fe5d7af4ba4652393c38
```

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
