### PR TITLE
Add support for arm64 archives

### DIFF
--- a/actions/action.go
+++ b/actions/action.go
@@ -65,6 +65,12 @@ func NewOutputs(uri string, latestVersion *semver.Version, additionalOutputs Out
 				return nil, fmt.Errorf("unable to calculate source sha256\n%w", err)
 			}
 			outputs["source_sha256"] = sourceSha256
+		} else if k == "arm64-uri" {
+			arm64Sha256, err := SHA256FromURI(v, mods...)
+			if err != nil {
+				return nil, fmt.Errorf("unable to calculate arm64 sha256\n%w", err)
+			}
+			outputs["arm64_sha256"] = arm64Sha256
 		}
 		outputs[k] = v
 	}


### PR DESCRIPTION
## Summary
Add support for arm64 archives
* [x] bellsoft liberica
* [x] watchexec (via github-release-dependency)
* [x] syft (via github-release-dependency)
* [x] upx (via github-release-dependency)

## Use Cases
We need buildpacks to have arm64 metadata, to enable dual arch support

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
