### PR TITLE
Allow setting the architecture for bellsoft update action

### DIFF
--- a/actions/bellsoft-liberica-dependency/main.go
+++ b/actions/bellsoft-liberica-dependency/main.go
@@ -47,8 +47,15 @@ func main() {
 		panic(fmt.Errorf("product must either be liberica or nik"))
 	}
 
+	// curl https://api.bell-sw.com/v1/liberica/architectures
+	//  `["arm", "ppc", "sparc", "x86"]`
+	arch, ok := inputs["arch"]
+	if !ok {
+		arch = "x86"
+	}
+
 	commonStaticParams := "&version-modifier=latest"
-	uriStaticParams := "?arch=x86" +
+	uriStaticParams := fmt.Sprintf("?arch=%s", arch) +
 		"&bitness=64" +
 		"&os=linux" +
 		"&package-type=tar.gz" +


### PR DESCRIPTION
## Summary

This passes the arch through to the Bellsoft API. It enables a job to pass in INPUT_ARCH and control that value.

Runs without INPUT_ARCH and defaults to `x86`. This persists the current behavior and should make it so pipeline-descriptors don't need to be updated.

```
dmikusa@oddjob-14188 ~/C/O/p/p/a/bellsoft-liberica-dependency (main) [1]> INPUT_TYPE=jdk INPUT_VERSION=17 INPUT_PRODUCT=liberica GITHUB_OUTPUT=./tmp go run main.go
dmikusa@oddjob-14188 ~/C/O/p/p/a/bellsoft-liberica-dependency (main)> cat ./tmp
uri<<d93c34efd6b8b135938d10d7f45f4f0b
https://github.com/bell-sw/Liberica/releases/download/17.0.9+11/bellsoft-jdk17.0.9+11-linux-amd64.tar.gz
d93c34efd6b8b135938d10d7f45f4f0b
version<<d93c34efd6b8b135938d10d7f45f4f0b
17.0.9
d93c34efd6b8b135938d10d7f45f4f0b
source_sha256<<d93c34efd6b8b135938d10d7f45f4f0b
3bf0ba5c38c65270ad41d5c0ebba40bf396d9542e3cc40dce2085f5ef608e9b3
d93c34efd6b8b135938d10d7f45f4f0b
source<<d93c34efd6b8b135938d10d7f45f4f0b
https://github.com/bell-sw/Liberica/releases/download/17.0.9+11/bellsoft-jdk17.0.9+11-src.tar.gz
d93c34efd6b8b135938d10d7f45f4f0b
sha256<<d93c34efd6b8b135938d10d7f45f4f0b
9d7f3fafa3cab04fd14ef42393291b2b4dda9a11e064949f3ffcc55fb832fe19
d93c34efd6b8b135938d10d7f45f4f0b
```

This overrides the default arch with the given arch, `arm` in this case.

```
dmikusa@oddjob-14188 ~/C/O/p/p/a/bellsoft-liberica-dependency (main)> INPUT_TYPE=jdk INPUT_VERSION=17 INPUT_PRODUCT=liberica INPUT_ARCH=arm GITHUB_OUTPUT=./tmp go run main.go
dmikusa@oddjob-14188 ~/C/O/p/p/a/bellsoft-liberica-dependency (main)> cat ./tmp
source_sha256<<27f763af6eda56021bf1bc70254fc7f7
3bf0ba5c38c65270ad41d5c0ebba40bf396d9542e3cc40dce2085f5ef608e9b3
27f763af6eda56021bf1bc70254fc7f7
source<<27f763af6eda56021bf1bc70254fc7f7
https://github.com/bell-sw/Liberica/releases/download/17.0.9+11/bellsoft-jdk17.0.9+11-src.tar.gz
27f763af6eda56021bf1bc70254fc7f7
sha256<<27f763af6eda56021bf1bc70254fc7f7
19cecb8bcb8a74e6d24bfb2c61eae4489c5fb940af71c3a7c0e1be3136ceae03
27f763af6eda56021bf1bc70254fc7f7
uri<<27f763af6eda56021bf1bc70254fc7f7
https://github.com/bell-sw/Liberica/releases/download/17.0.9+11/bellsoft-jdk17.0.9+11-linux-aarch64.tar.gz
27f763af6eda56021bf1bc70254fc7f7
version<<27f763af6eda56021bf1bc70254fc7f7
17.0.9
27f763af6eda56021bf1bc70254fc7f7
```

## Use Cases

This will be used by the Bellsoft buildpack, which is going to add more update jobs to check for both architectures.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
