### PR TITLE
Remove old version number

### DIFF
--- a/octo/create_package.go
+++ b/octo/create_package.go
@@ -145,7 +145,7 @@ func ContributeCreatePackage(descriptor Descriptor) (*Contribution, error) {
 						},
 					},
 					{
-						Uses: "docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1",
+						Uses: fmt.Sprintf("docker://ghcr.io/buildpacks/actions/registry/request-add-entry:%s", BuildpackActionsVersion),
 						If:   fmt.Sprintf("${{ %t }}", descriptor.Package.Register),
 						With: map[string]interface{}{
 							"token":   descriptor.Package.RegistryToken,


### PR DESCRIPTION
Removes the static version number that is very old now and just lets it pull the latest