### PR TITLE
Restore missing integration tests

### DIFF
--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -52,3 +52,10 @@ jobs:
                 richgo test ./... -run Unit
               env:
                 RICHGO_FORCE_COLOR: "1"
+            - name: Run Integration Tests
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go test ./integration/... -run Integration

--- a/octo/test.go
+++ b/octo/test.go
@@ -227,9 +227,10 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 					Name: "Package Buildpack",
 					Run:  StatikString("/package-buildpack.sh"),
 					Env: map[string]string{
-						"FORMAT":   format,
-						"PACKAGES": "test",
-						"VERSION":  "${{ steps.version.outputs.version }}",
+						"FORMAT":         format,
+						"PACKAGES":       "test",
+						"VERSION":        "${{ steps.version.outputs.version }}",
+						"TTL_SH_PUBLISH": "false",
 					},
 				})
 		}

--- a/octo/test.go
+++ b/octo/test.go
@@ -94,17 +94,28 @@ func ContributeTest(descriptor Descriptor) (*Contribution, error) {
 
 		if len(integrationTestFiles) == 0 {
 			j.Steps = append(j.Steps, descriptor.Test.Steps...)
-		} else {
-			j.Steps = append(j.Steps, actions.Step{
-				Name: "Install richgo",
-				Run:  StatikString("/install-richgo.sh"),
-				Env:  map[string]string{"RICHGO_VERSION": RichGoVersion},
-			},
+		}
+
+		if len(integrationTestFiles) > 0 {
+			j.Steps = append(j.Steps,
+				actions.Step{
+					Name: "Install richgo",
+					Run:  StatikString("/install-richgo.sh"),
+					Env:  map[string]string{"RICHGO_VERSION": RichGoVersion},
+				},
 				actions.Step{
 					Name: "Run Tests",
 					Run:  StatikString("/run-unit-tests.sh"),
 					Env:  map[string]string{"RICHGO_FORCE_COLOR": "1"},
 				})
+
+			if !descriptor.Package.Enabled {
+				j.Steps = append(j.Steps,
+					actions.Step{
+						Name: "Run Integration Tests",
+						Run:  StatikString("/run-integration-tests.sh"),
+					})
+			}
 		}
 
 		w.Jobs["unit"] = j


### PR DESCRIPTION
## Summary

Integration tests are missing in this repo. A recent set integration tests to only run when packaging, but other repos may have integration test, like this one. This change adjusts it so that integration tests are added for any repo that has them.

This also fixes TTL_SH_PUBLISH, which was causing some noise when not set.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
