### PR TITLE
Convert to the arch used by the API within the action

### DIFF
--- a/actions/yourkit-dependency/main.go
+++ b/actions/yourkit-dependency/main.go
@@ -29,8 +29,12 @@ func main() {
 	inputs := actions.NewInputs()
 
 	arch, ok := inputs["arch"]
-	if !ok || (arch != "arm64" && arch != "x64") {
-		panic(fmt.Errorf("arch must be specified [arm64, x64]"))
+	if !ok || (arch != "arm64" && arch != "amd64") {
+		panic(fmt.Errorf("arch must be specified [arm64, amd64]"))
+	}
+
+	if arch == "amd64" {
+		arch = "x64"
 	}
 
 	c := colly.NewCollector()


### PR DESCRIPTION
The method of fetching updates requires an arch of `x64` instead of `amd64`. We need to convert this within the action because everything in our pipelines expects the arches to match GOARCH values.