### PR TITLE
Change foojay update checker to include the architecture

### DIFF
--- a/actions/Dockerfile
+++ b/actions/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build-stage
+FROM golang:1.22 as build-stage
 
 WORKDIR /src
 ENV GO111MODULE=on CGO_ENABLED=0


### PR DESCRIPTION
## Summary

Enable the foojay update checker to look for architecture-specific dependencies. i.e. arm64 support

## Use Cases

ARM64!

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
