### PR TITLE
Strip patch version off Go version

### DIFF
--- a/octo/update-go.sh
+++ b/octo/update-go.sh
@@ -7,7 +7,7 @@ if [ -z "${GO_VERSION:-}" ]; then
     exit 1
 fi
 
-OLD_GO_VERSION=$(grep -P '^go \d\.\d+' go.mod | cut -d ' ' -f 2)
+OLD_GO_VERSION=$(grep -P '^go \d\.\d+' go.mod | cut -d ' ' -f 2 | cut -d '.' -f 1-2)
 
 go mod edit -go="$GO_VERSION"
 go mod tidy


### PR DESCRIPTION
## Summary

The input version is two digits (major.minor), but for some buildpacks the version in the go.mod file has three digits. This didn't actually change the go.mod file, but it caused a mismatch if old/new versions, which caused the wrong title to be filed on PRs.

Stripping off the patch version of the go version read out of the go.mod file should enable it to match unless the major.minor is different.
