### PR TITLE
Revert "Use a single commit for package updates"

### DIFF
--- a/octo/package_dependencies.go
+++ b/octo/package_dependencies.go
@@ -167,7 +167,7 @@ func contributePackageDependency(descriptor Descriptor, name string, bpId string
 
 Bumps %[1]s from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}.`, name),
 							"signoff":       true,
-							"branch":        "update/packages",
+							"branch":        fmt.Sprintf("update/package/%s", filepath.Base(name)),
 							"delete-branch": true,
 							"title":         fmt.Sprintf("Bump %s from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}", name),
 							"body":          fmt.Sprintf("Bumps [`%[1]s`](https://%[1]s) from [`${{ steps.package.outputs.old-version }}`](https://%[1]s:${{ steps.package.outputs.old-version }}) to [`${{ steps.package.outputs.new-version }}`](https://%[1]s:${{ steps.package.outputs.new-version }}).", name),


### PR DESCRIPTION
This reverts commit c985237ea5ef8cbc836166ddbaf2f43149512fb6.

we need to find out a way to have Peter Evans create PR to re use the same branch for different updates; but for now, it will just override

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
