### PR TITLE
Only match openj9 version if we can

### DIFF
--- a/actions/ibm-semeru-dependency/main.go
+++ b/actions/ibm-semeru-dependency/main.go
@@ -130,13 +130,12 @@ func main() {
 	// IBM Semeru uses the OpenJ9 version in the CPE, ex: 0.29.1
 	//
 	// This adjusts the update job to set the CPE in this way instead
-	// of using the standard version format
+	// of using the standard version format (if it's available)
 	re = regexp.MustCompile(`openj9-([\d]+\.[\d]+\.[\d]+).*?\/`)
 	matches := re.FindStringSubmatch(url)
-	if matches == nil || len(matches) != 2 {
-		panic(fmt.Errorf("unable to parse OpenJ9 version: %s", matches))
+	if matches != nil && len(matches) == 2 {
+		outputs["cpe"] = matches[1]
 	}
-	outputs["cpe"] = matches[1]
 
 	outputs.Write()
 }


### PR DESCRIPTION
## Summary

Fix Eclipse OpenJ9 updater.

## Use Cases

It looks like recent releases do not have the openj9 version in the file name anymore. This seems to have changed with https://github.com/ibmruntimes/semeru25-binaries/releases/tag/jdk-25.0.3.0 and https://github.com/ibmruntimes/semeru26-binaries/releases/tag/jdk-26.0.1.0. Compared to previous releases, which did have it. Idk if this will come back, but the code is set to use the OpenJ9 verison if it's present and if not, then it'll use the Java version. This is a best effort.
